### PR TITLE
Cache image resources locally for authenticated connections

### DIFF
--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
@@ -1,12 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Threading.Tasks;
-using Windows.Storage;
-using Windows.Storage.Streams;
 using Windows.UI.Xaml.Data;
 using XBMCRemoteRT.Helpers;
 

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
@@ -24,6 +24,7 @@ namespace XBMCRemoteRT.Converters
                 {
                     // Get Kodi proxy image address
                     imageURI = CacheManager.GetRemoteUri(imagePath);
+                }
             }
             else
             {

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
@@ -106,7 +106,6 @@ namespace XBMCRemoteRT.Converters
             HttpClient client = new HttpClient();
             client.BaseAddress = new Uri(imageUri.Scheme + "://" + imageUri.Authority);
             HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, imageUri.AbsolutePath);
-            // TODO: Test for active connection? What are possible errors with ConnectionManager?
             if (ConnectionManager.CurrentConnection.Password != String.Empty)
             {
                 req.Headers.Authorization = new AuthenticationHeaderValue(

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
@@ -15,7 +15,7 @@ namespace XBMCRemoteRT.Converters
             {
                 // Only apply cache logic if authentication is in use. If not,
                 // allow the image to be consumed from Kodi.
-                if (ConnectionManager.CurrentConnection.Password != String.Empty)
+                if (ConnectionManager.CurrentConnection.HasCredentials())
                 {
                     // Get path to locally cached image
                     imageURI = CacheManager.GetCacheUri(imagePath);

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
@@ -1,9 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.IO;
 using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
-using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.Storage.Streams;
 using Windows.UI.Xaml.Data;
 using XBMCRemoteRT.Helpers;
 
@@ -15,19 +17,30 @@ namespace XBMCRemoteRT.Converters
         {
             string imagePath = (value == null) ? string.Empty : (string)value;
             string imageURL = string.Empty;
-            if (imagePath.Length > 8)
+            string proxyScheme = "image://";
+            string httpScheme = "http://";
+            // TODO: are there other possible schemes for imagePath?
+            if (imagePath.StartsWith(proxyScheme))
             {
-                string uri = imagePath.Substring(8);
-                //if (uri.StartsWith("http"))
-                //{
-                //    imageURL = WebUtility.UrlDecode(uri).TrimEnd('/');
-                //}
-                //else
-                //{
+                string uri = imagePath.Substring(proxyScheme.Length);
+
+                // Transform URI to local storage path
+                string decodedUri = WebUtility.UrlDecode(uri).Trim('/');
+                if (decodedUri.StartsWith(httpScheme))
+                {
+                    // TODO: Proxy http sources through Kodi? Good for consistency I guess: decodedUri = decodedUri.Substring(httpScheme.Length);
+                    return decodedUri;
+                }
+                // TODO: I am running Kodi on Ubuntu. What needs to change for Windows paths?
+                string storagePath = decodedUri.Replace('/', '\\');
+                // TODO: What happens if the URI passed to XAML has invalid characters?
+                imageURL = ApplicationData.Current.TemporaryFolder.Path + '\\' + storagePath;
+
+                // Build Kodi proxy image address
                 var encodedUri = WebUtility.UrlEncode(uri);
                 string baseUrlString = "http://" + ConnectionManager.CurrentConnection.IpAddress + ":" + ConnectionManager.CurrentConnection.Port.ToString() + "/image/image://";
-                imageURL = baseUrlString + encodedUri;
-                //}
+                Uri imageUri = new Uri(baseUrlString + encodedUri);
+                CheckImageStorage(storagePath, imageUri);
             }
             else
             {
@@ -35,6 +48,107 @@ namespace XBMCRemoteRT.Converters
             }
             Uri imageURI = new Uri(imageURL, UriKind.Absolute);
             return imageURI;
+        }
+
+        private async void CheckImageStorage(string storagePath, Uri imageUri)
+        {
+            string filename = Path.GetFileName(storagePath);
+            string[] path = Path.GetDirectoryName(storagePath).Split('\\');
+
+            // Traverse directories to file location
+            StorageFolder parent = ApplicationData.Current.TemporaryFolder;
+            try
+            {
+                foreach (string dir in path)
+                {
+                    bool dirExists = false;
+                    try
+                    {
+                        parent = await parent.GetFolderAsync(dir);
+                        dirExists = true;
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        // Image is not cached, continue creating directories
+                    }
+
+                    if (!dirExists)
+                    {
+                        parent = await parent.CreateFolderAsync(dir);
+                        System.Diagnostics.Debug.WriteLine("Created " + parent.Path);
+                    }
+                }
+
+                // Attempt to open file
+                bool fileExists = false;
+                try
+                {
+                    await parent.GetFileAsync(filename);
+                    fileExists = true;
+                    // TODO: Check file age and refresh cached image. Age is a bad way to do it though.
+                }
+                catch (FileNotFoundException)
+                {
+                    // Image is not cached, download and save file
+                }
+                if (!fileExists)
+                {
+                    // TODO: Can I create the file only after request is complete? That way we avoid empty files from aborted requests
+                    // or it might be okay actually because file isn't closed
+                    StorageFile file = await parent.CreateFileAsync(filename);
+                    System.Diagnostics.Debug.WriteLine("Creating " + file.Path);
+                    GetImage(imageUri, file);
+                }
+            }
+            catch (ArgumentException)
+            {
+                // Invalid characters in folder or file name. See 
+                // Path.GetInvalid(Path|FileName)Chars. We could sanitize the 
+                // path, but since the paths should also be valid on the host
+                // we just swallow the exception and the image won't be
+                // downloaded.
+            }
+        }
+
+        private async void GetImage(Uri imageUri, StorageFile outFile)
+        {
+            // Download the image with HTTP Basic auth
+            HttpClient client = new HttpClient();
+            client.BaseAddress = new Uri(imageUri.Scheme + "://" + imageUri.Authority);
+            HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, imageUri.AbsolutePath);
+            // TODO: Test for active connection? What are possible errors with ConnectionManager?
+            if (ConnectionManager.CurrentConnection.Password != String.Empty)
+            {
+                req.Headers.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    System.Convert.ToBase64String(Encoding.UTF8.GetBytes(
+                        String.Format("{0}:{1}",
+                        ConnectionManager.CurrentConnection.Username,
+                        ConnectionManager.CurrentConnection.Password)
+                    ))
+                );
+            }
+
+            HttpResponseMessage res = await client.SendAsync(req);
+            // TODO: Ensure requests are cached
+            if (res.IsSuccessStatusCode)
+            {
+                IInputStream imageStream = (await res.Content.ReadAsStreamAsync()).AsInputStream();
+                DataReader reader = new DataReader(imageStream);
+
+                IRandomAccessStream fileStream = await outFile.OpenAsync(FileAccessMode.ReadWrite);
+
+                await reader.LoadAsync(1024);
+                while (reader.UnconsumedBufferLength > 0)
+                {
+                    await fileStream.WriteAsync(reader.ReadBuffer(reader.UnconsumedBufferLength));
+                    await reader.LoadAsync(1024);
+                }
+
+                await fileStream.FlushAsync();
+                imageStream.Dispose();
+            }
+            // TODO: Handle failed download by ensuring file is not saved
         }
 
 

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.Storage.Streams;
 using Windows.UI.Xaml.Data;
@@ -18,29 +19,19 @@ namespace XBMCRemoteRT.Converters
             string imagePath = (value == null) ? string.Empty : (string)value;
             string imageURL = string.Empty;
             string proxyScheme = "image://";
-            string httpScheme = "http://";
             // TODO: are there other possible schemes for imagePath?
+            // TODO: Only apply cache logic if user is using authentication
             if (imagePath.StartsWith(proxyScheme))
             {
-                string uri = imagePath.Substring(proxyScheme.Length);
-
-                // Transform URI to local storage path
-                string decodedUri = WebUtility.UrlDecode(uri).Trim('/');
-                if (decodedUri.StartsWith(httpScheme))
-                {
-                    // TODO: Proxy http sources through Kodi? Good for consistency I guess: decodedUri = decodedUri.Substring(httpScheme.Length);
-                    return decodedUri;
-                }
-                // TODO: I am running Kodi on Ubuntu. What needs to change for Windows paths?
-                string storagePath = decodedUri.Replace('/', '\\');
-                // TODO: What happens if the URI passed to XAML has invalid characters?
-                imageURL = ApplicationData.Current.TemporaryFolder.Path + '\\' + storagePath;
+                // Hash the image proxy path into local storage file name
+                string storageFileName = MD5Core.GetHashString(imagePath) + ".tmp";
+                imageURL = ApplicationData.Current.TemporaryFolder.Path + '\\' + storageFileName;
 
                 // Build Kodi proxy image address
-                var encodedUri = WebUtility.UrlEncode(uri);
-                string baseUrlString = "http://" + ConnectionManager.CurrentConnection.IpAddress + ":" + ConnectionManager.CurrentConnection.Port.ToString() + "/image/image://";
+                var encodedUri = WebUtility.UrlEncode(imagePath);
+                string baseUrlString = "http://" + ConnectionManager.CurrentConnection.IpAddress + ":" + ConnectionManager.CurrentConnection.Port.ToString() + "/image/";
                 Uri imageUri = new Uri(baseUrlString + encodedUri);
-                CheckImageStorage(storagePath, imageUri);
+                CacheImage(imageUri, storageFileName);
             }
             else
             {
@@ -50,68 +41,61 @@ namespace XBMCRemoteRT.Converters
             return imageURI;
         }
 
-        private async void CheckImageStorage(string storagePath, Uri imageUri)
+        // TODO: Externalize these methods so the same logic can be applied to StringToImageBrushConverter
+        private async void CacheImage(Uri imageUri, string storageFileName)
         {
-            string filename = Path.GetFileName(storagePath);
-            string[] path = Path.GetDirectoryName(storagePath).Split('\\');
+            string filename = storageFileName;
 
-            // Traverse directories to file location
+            // Attempt to open file in app temp folder
             StorageFolder parent = ApplicationData.Current.TemporaryFolder;
+            bool fileExists = false;
             try
             {
-                foreach (string dir in path)
-                {
-                    bool dirExists = false;
-                    try
-                    {
-                        parent = await parent.GetFolderAsync(dir);
-                        dirExists = true;
-                    }
-                    catch (FileNotFoundException)
-                    {
-                        // Image is not cached, continue creating directories
-                    }
-
-                    if (!dirExists)
-                    {
-                        parent = await parent.CreateFolderAsync(dir);
-                        System.Diagnostics.Debug.WriteLine("Created " + parent.Path);
-                    }
-                }
-
-                // Attempt to open file
-                bool fileExists = false;
-                try
-                {
-                    await parent.GetFileAsync(filename);
-                    fileExists = true;
-                    // TODO: Check file age and refresh cached image. Age is a bad way to do it though.
-                }
-                catch (FileNotFoundException)
-                {
-                    // Image is not cached, download and save file
-                }
-                if (!fileExists)
-                {
-                    // TODO: Can I create the file only after request is complete? That way we avoid empty files from aborted requests
-                    // or it might be okay actually because file isn't closed
-                    StorageFile file = await parent.CreateFileAsync(filename);
-                    System.Diagnostics.Debug.WriteLine("Creating " + file.Path);
-                    GetImage(imageUri, file);
-                }
+                await parent.GetFileAsync(filename);
+                fileExists = true;
+                // TODO: Check file age and refresh cached image. Age is a bad way to do it though.
             }
-            catch (ArgumentException)
+            catch (FileNotFoundException)
             {
-                // Invalid characters in folder or file name. See 
-                // Path.GetInvalid(Path|FileName)Chars. We could sanitize the 
-                // path, but since the paths should also be valid on the host
-                // we just swallow the exception and the image won't be
-                // downloaded.
+                // Image is not cached, download and save file
+            }
+            if (!fileExists)
+            {
+                System.Diagnostics.Debug.WriteLine("Creating " + filename);
+                Stream imageStream = await GetImage(imageUri);
+
+                if (imageStream != null)
+                {
+                    // Prepare input image stream
+                    IInputStream inStream = imageStream.AsInputStream();
+                    DataReader reader = new DataReader(inStream);
+
+                    // Prepare output file stream
+                    StorageFile file = await parent.CreateFileAsync(filename);
+                    IRandomAccessStream fileStream = await file.OpenAsync(FileAccessMode.ReadWrite);
+
+                    // Buffered write to file
+                    await reader.LoadAsync(1024);
+                    while (reader.UnconsumedBufferLength > 0)
+                    {
+                        await fileStream.WriteAsync(reader.ReadBuffer(reader.UnconsumedBufferLength));
+                        await reader.LoadAsync(1024);
+                    }
+
+                    await fileStream.FlushAsync();
+                    inStream.Dispose();
+                    // TODO: Handle write task canceled exceptions, or prepare for corrupted images
+                    // TODO: If this image was just created, it is likely that the
+                    // ImageSource consuming the path aborted due to file not 
+                    // found. Can we "refresh" the ImageSource?
+                }
             }
         }
 
-        private async void GetImage(Uri imageUri, StorageFile outFile)
+        private async Task<Stream> GetImage(Uri imageUri)
         {
+            Stream imageStream = null;
+
             // Download the image with HTTP Basic auth
             HttpClient client = new HttpClient();
             client.BaseAddress = new Uri(imageUri.Scheme + "://" + imageUri.Authority);
@@ -130,25 +114,12 @@ namespace XBMCRemoteRT.Converters
             }
 
             HttpResponseMessage res = await client.SendAsync(req);
-            // TODO: Ensure requests are cached
             if (res.IsSuccessStatusCode)
             {
-                IInputStream imageStream = (await res.Content.ReadAsStreamAsync()).AsInputStream();
-                DataReader reader = new DataReader(imageStream);
-
-                IRandomAccessStream fileStream = await outFile.OpenAsync(FileAccessMode.ReadWrite);
-
-                await reader.LoadAsync(1024);
-                while (reader.UnconsumedBufferLength > 0)
-                {
-                    await fileStream.WriteAsync(reader.ReadBuffer(reader.UnconsumedBufferLength));
-                    await reader.LoadAsync(1024);
-                }
-
-                await fileStream.FlushAsync();
-                imageStream.Dispose();
+                imageStream = await res.Content.ReadAsStreamAsync();
             }
-            // TODO: Handle failed download by ensuring file is not saved
+
+            return imageStream;
         }
 
 

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
@@ -15,7 +15,6 @@ namespace XBMCRemoteRT.Converters
             {
                 // Only apply cache logic if authentication is in use. If not,
                 // allow the image to be consumed from Kodi.
-                // TODO: Apply same logic to StringToImageBrushConverter
                 if (ConnectionManager.CurrentConnection.Password != String.Empty)
                 {
                     // Get path to locally cached image

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/ImagePathConverter.cs
@@ -17,116 +17,30 @@ namespace XBMCRemoteRT.Converters
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             string imagePath = (value == null) ? string.Empty : (string)value;
-            string imageURL = string.Empty;
+            Uri imageURI = null;
             string proxyScheme = "image://";
-            // TODO: are there other possible schemes for imagePath?
             if (imagePath.StartsWith(proxyScheme))
             {
-                // Build Kodi proxy image address
-                var encodedUri = WebUtility.UrlEncode(imagePath);
-                string baseUrlString = "http://" + ConnectionManager.CurrentConnection.IpAddress + ":" + ConnectionManager.CurrentConnection.Port.ToString() + "/image/";
-                imageURL = baseUrlString + encodedUri;
-
                 // Only apply cache logic if authentication is in use. If not,
                 // allow the image to be consumed from Kodi.
+                // TODO: Apply same logic to StringToImageBrushConverter
                 if (ConnectionManager.CurrentConnection.Password != String.Empty)
                 {
-                    Uri imageUri = new Uri(imageURL);
-
-                    // Hash the image proxy path into local storage file name
-                    string storageFileName = MD5Core.GetHashString(imagePath) + ".tmp";
-                    imageURL = ApplicationData.Current.TemporaryFolder.Path + '\\' + storageFileName;
-
-                    CacheImage(imageUri, storageFileName);
+                    // Get path to locally cached image
+                    imageURI = CacheManager.GetCacheUri(imagePath);
+                }
+                else
+                {
+                    // Get Kodi proxy image address
+                    imageURI = CacheManager.GetRemoteUri(imagePath);
                 }
             }
             else
             {
-                imageURL = "ms-appx:///Assets/DefaultArt.jpg";
+                imageURI = new Uri("ms-appx:///Assets/DefaultArt.jpg", UriKind.Absolute);
             }
-            Uri imageURI = new Uri(imageURL, UriKind.Absolute);
             return imageURI;
         }
-
-        // TODO: Externalize these methods so the same logic can be applied to StringToImageBrushConverter
-        private async void CacheImage(Uri imageUri, string storageFileName)
-        {
-            string filename = storageFileName;
-
-            // Attempt to open file in app temp folder
-            StorageFolder parent = ApplicationData.Current.TemporaryFolder;
-            bool fileExists = false;
-            try
-            {
-                await parent.GetFileAsync(filename);
-                fileExists = true;
-                // TODO: Check file age and refresh cached image. Age is a bad way to do it though.
-            }
-            catch (FileNotFoundException)
-            {
-                // Image is not cached, download and save file
-            }
-            if (!fileExists)
-            {
-                Stream imageStream = await GetImage(imageUri);
-
-                if (imageStream != null)
-                {
-                    // Prepare input image stream
-                    IInputStream inStream = imageStream.AsInputStream();
-                    DataReader reader = new DataReader(inStream);
-
-                    // Prepare output file stream
-                    StorageFile file = await parent.CreateFileAsync(filename);
-                    IRandomAccessStream fileStream = await file.OpenAsync(FileAccessMode.ReadWrite);
-
-                    // Buffered write to file
-                    await reader.LoadAsync(1024);
-                    while (reader.UnconsumedBufferLength > 0)
-                    {
-                        await fileStream.WriteAsync(reader.ReadBuffer(reader.UnconsumedBufferLength));
-                        await reader.LoadAsync(1024);
-                    }
-
-                    await fileStream.FlushAsync();
-                    inStream.Dispose();
-                    // TODO: Handle write task canceled exceptions, or prepare for corrupted images
-                    // TODO: If this image was just created, it is likely that the
-                    // ImageSource consuming the path aborted due to file not 
-                    // found. Can we "refresh" the ImageSource?
-                }
-            }
-        }
-
-        private async Task<Stream> GetImage(Uri imageUri)
-        {
-            Stream imageStream = null;
-
-            // Download the image with HTTP Basic auth
-            HttpClient client = new HttpClient();
-            client.BaseAddress = new Uri(imageUri.Scheme + "://" + imageUri.Authority);
-            HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, imageUri.AbsolutePath);
-            if (ConnectionManager.CurrentConnection.Password != String.Empty)
-            {
-                req.Headers.Authorization = new AuthenticationHeaderValue(
-                    "Basic",
-                    System.Convert.ToBase64String(Encoding.UTF8.GetBytes(
-                        String.Format("{0}:{1}",
-                        ConnectionManager.CurrentConnection.Username,
-                        ConnectionManager.CurrentConnection.Password)
-                    ))
-                );
-            }
-
-            HttpResponseMessage res = await client.SendAsync(req);
-            if (res.IsSuccessStatusCode)
-            {
-                imageStream = await res.Content.ReadAsStreamAsync();
-            }
-
-            return imageStream;
-        }
-
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/StringToImageBrushConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/StringToImageBrushConverter.cs
@@ -22,7 +22,7 @@ namespace XBMCRemoteRT.Converters
             {
                 // Only apply cache logic if authentication is in use. If not,
                 // allow the image to be consumed from Kodi.
-                if (ConnectionManager.CurrentConnection.Password != String.Empty)
+                if (ConnectionManager.CurrentConnection.HasCredentials())
                 {
                     // Get path to locally cached image
                     imageURI = CacheManager.GetCacheUri(imagePath);

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/StringToImageBrushConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/StringToImageBrushConverter.cs
@@ -15,34 +15,30 @@ namespace XBMCRemoteRT.Converters
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            string imagePath = (string)value;
-            string imageURL = string.Empty;
-            if (imagePath == null)
-                imagePath = String.Empty;
-            if (imagePath.Length > 8)
+            string imagePath = (value == null) ? string.Empty : (string)value;
+            Uri imageURI = null;
+            string proxyScheme = "image://";
+            if (imagePath.StartsWith(proxyScheme))
             {
-                string uri = imagePath.Substring(8);
-                if (uri.StartsWith("http"))
+                // Only apply cache logic if authentication is in use. If not,
+                // allow the image to be consumed from Kodi.
+                if (ConnectionManager.CurrentConnection.Password != String.Empty)
                 {
-                    imageURL = WebUtility.UrlDecode(uri).TrimEnd('/');
+                    // Get path to locally cached image
+                    imageURI = CacheManager.GetCacheUri(imagePath);
                 }
                 else
                 {
-                    var encodedUri = WebUtility.UrlEncode(uri);
-                    string baseUrlString = "http://" + ConnectionManager.CurrentConnection.IpAddress + ":" + ConnectionManager.CurrentConnection.Port.ToString() + "/image/image://";
-                    imageURL = baseUrlString + encodedUri;
+                    // Get Kodi proxy image address
+                    imageURI = CacheManager.GetRemoteUri(imagePath);
                 }
-            }
-            else
-            {
-                imageURL = "";
             }
 
             ImageBrush imageBrush = new ImageBrush();
             imageBrush.Stretch = Stretch.UniformToFill;
             imageBrush.Opacity = 0.6;
-            if(!string.IsNullOrEmpty(imageURL))
-                imageBrush.ImageSource = new BitmapImage(new Uri(imageURL, UriKind.RelativeOrAbsolute));
+            if(imageURI != null)
+                imageBrush.ImageSource = new BitmapImage(imageURI);
             return imageBrush;
         }
 

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
@@ -77,7 +77,6 @@ namespace XBMCRemoteRT.Helpers
             string storagePath = Path.Combine(GetCacheFolder().Path, storageFileName);
             imageUri = new Uri(storagePath, UriKind.Absolute);
 
-            // TODO: Ideally, we've predicted all the possible images and cached them, but cache misses can be handled by simply downloading the image to the cache. Only a mild inconvenience for the user.
             VerifyCacheAsync(GetRemoteUri(imagePath), storageFileName);
 
             return imageUri;
@@ -92,8 +91,7 @@ namespace XBMCRemoteRT.Helpers
         {
             if (!(await IsFileCachedAsync(filename)))
             {
-
-                // TODO: cache miss. download and save.
+                // Cache miss, download and save the image
                 Stream imageStream = await GetImageStreamAsync(imageUri);
                 await WriteFileAsync(imageStream, filename);
                 // TODO: Check file age and refresh cached image. Age is a bad way to do it though.
@@ -210,7 +208,6 @@ namespace XBMCRemoteRT.Helpers
             // Empty the temp folder
             StorageFolder parent = GetCacheFolder();
             IEnumerable<StorageFile> cachedFiles = await parent.GetFilesAsync();
-            // TODO: Any issues with deleting while I iterate this list?
             foreach (StorageFile file in cachedFiles)
             {
                 await file.DeleteAsync();

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
@@ -152,12 +152,14 @@ namespace XBMCRemoteRT.Helpers
         /// <param name="filename">Cached file name</param>
         private static async Task VerifyCacheAsync(Uri imageUri, string filename)
         {
+            // TODO: Consider expiring the cache somehow. As it stands, new 
+            // images will be added to the cache at connection select, but
+            // changed images are only reflected on manual update by user.
             if (!(await IsFileCachedAsync(filename)))
             {
                 // Cache miss, download and save the image
                 Stream imageStream = await GetImageStreamAsync(imageUri);
                 await WriteFileAsync(imageStream, filename);
-                // TODO: Check file age and refresh cached image. Age is a bad way to do it though.
             }
         }
 

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.Storage.Streams;
+using XBMCRemoteRT.Models;
+
+namespace XBMCRemoteRT.Helpers
+{
+    public class CacheManager
+    {
+        public static async void InitCacheAsync()
+        {
+            IEnumerable<string> imagePaths = await GetAllImagesAsync();
+            foreach (string imagePath in imagePaths)
+            {
+                Stream imageStream = await GetImageStream(GetRemoteUri(imagePath));
+                if (imageStream != null)
+                {
+                    // TODO: Save image
+                }
+                else
+                {
+                    // TODO: Handle failed image downloads with friendly error message
+                }
+            }
+        }
+
+        public static async Task<IEnumerable<string>> GetAllImagesAsync()
+        {
+            List<string> imagePaths = new List<string>();
+
+            // TODO: Compile a collection of potential images from movies, music, and TV.
+
+            return imagePaths;
+        }
+
+        /// <summary>
+        /// Returns remote location of the image on the currently connected Kodi server.
+        /// </summary>
+        /// <param name="imagePath">Path on remote server to the resource. Usually begins with "image://"</param>
+        /// <returns>Location of the resource on the currently connected Kodi server. null if not connected or if imagePath is invalid.</returns>
+        public static Uri GetRemoteUri(string imagePath)
+        {
+            Uri imageUri = null;
+
+            // Build Kodi proxy image address
+            ConnectionItem con = ConnectionManager.CurrentConnection;
+            if (con != null)
+            {
+                string baseUrlString = "http://" + con.IpAddress + ":" + con.Port.ToString() + "/image/";
+                string encodedUri = WebUtility.UrlEncode(imagePath);
+                try
+                {
+                    imageUri = new Uri(baseUrlString + encodedUri);
+                }
+                catch (FormatException) { }
+            }
+            return imageUri;
+        }
+
+        /// <summary>
+        /// Returns path to a locally cached copy of the image. If the imagePath has not yet been cached, download is initiated but the Uri remains the same.
+        /// </summary>
+        /// <param name="imagePath">Path on remote server to the resource. Usually begins with "image://"</param>
+        /// <returns>Path to locally cached copy of the resource</returns>
+        public static Uri GetCacheUri(string imagePath)
+        {
+            Uri imageUri = null;
+
+            // TODO: Should each connection have its own cache? Two connections could have different images at the same path, but unlikely.
+            string storageFileName = MD5Core.GetHashString(imagePath) + ".tmp";
+            string storagePath = Path.Combine(ApplicationData.Current.TemporaryFolder.Path, storageFileName);
+            imageUri = new Uri(storagePath, UriKind.Absolute);
+
+            // TODO: Ideally, we've predicted all the possible images and cached them, but cache misses can be handled by simply downloading the image to the cache. Only a mild inconvenience for the user.
+            VerifyCache(storageFileName);
+
+            return imageUri;
+        }
+
+        private static async void VerifyCache(string filename)
+        {
+            if (!(await IsFileCached(filename)))
+            {
+                // TODO: cache miss. download and save.
+                // TODO: Check file age and refresh cached image. Age is a bad way to do it though.
+            }
+        }
+
+        private static async Task<bool> IsFileCached(string filename)
+        {
+
+            // Attempt to open file in app temp folder
+            StorageFolder parent = ApplicationData.Current.TemporaryFolder;
+            bool fileExists = false;
+            try
+            {
+                await parent.GetFileAsync(filename);
+                fileExists = true;
+            }
+            catch (FileNotFoundException)
+            {
+                // Image is not cached
+            }
+            return fileExists;
+        }
+
+        /// <summary>
+        /// Downloads image content from a remote location. TODO: Requests are cached.
+        /// </summary>
+        /// <param name="imageUri">Image location</param>
+        /// <returns>Stream content of the HTTP response. null if not connected, imageUri is invalid, or HTTP response is not OK</returns>
+        private static async Task<Stream> GetImageStream(Uri imageUri)
+        {
+            Stream imageStream = null;
+
+            // Download the image with HTTP Basic auth
+            HttpClient client = new HttpClient();
+            client.BaseAddress = new Uri(imageUri.Scheme + "://" + imageUri.Authority);
+            HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, imageUri.AbsolutePath);
+            ConnectionItem con = ConnectionManager.CurrentConnection;
+            if (con != null && con.Password != String.Empty)
+            {
+                req.Headers.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    System.Convert.ToBase64String(Encoding.UTF8.GetBytes(
+                        String.Format("{0}:{1}",
+                        con.Username,
+                        con.Password)
+                    ))
+                );
+            }
+
+            HttpResponseMessage res = await client.SendAsync(req);
+            if (res.IsSuccessStatusCode)
+            {
+                imageStream = await res.Content.ReadAsStreamAsync();
+            }
+
+            return imageStream;
+        }
+
+        private static async void WriteFile(Stream stream, string filename)
+        {
+
+            // Prepare input image stream
+            IInputStream inStream = stream.AsInputStream();
+            DataReader reader = new DataReader(inStream);
+
+            // Prepare output file stream
+            StorageFolder parent = ApplicationData.Current.TemporaryFolder;
+            StorageFile file = null;
+            try
+            {
+                file = await parent.CreateFileAsync(filename, CreationCollisionOption.ReplaceExisting);
+            }
+            catch (Exception) {
+            }
+
+            if (file != null)
+            {
+                IRandomAccessStream fileStream = await file.OpenAsync(FileAccessMode.ReadWrite);
+                // Buffered write to file
+                await reader.LoadAsync(1024);
+                while (reader.UnconsumedBufferLength > 0)
+                {
+                    await fileStream.WriteAsync(reader.ReadBuffer(reader.UnconsumedBufferLength));
+                    await reader.LoadAsync(1024);
+                }
+
+                await fileStream.FlushAsync();
+                inStream.Dispose();
+                // TODO: Handle write task canceled exceptions, or prepare for corrupted images
+            }
+        }
+
+        public static async void ClearCacheAsync()
+        {
+            // TODO: Empty the temp folder for the current connection
+        }
+    }
+}

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
@@ -198,7 +198,7 @@ namespace XBMCRemoteRT.Helpers
             client.BaseAddress = new Uri(imageUri.Scheme + "://" + imageUri.Authority);
             HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, imageUri.AbsolutePath);
             ConnectionItem con = ConnectionManager.CurrentConnection;
-            if (con != null && con.Password != String.Empty)
+            if (con != null && con.HasCredentials())
             {
                 req.Headers.Authorization = new AuthenticationHeaderValue(
                     "Basic",

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
@@ -65,7 +65,7 @@ namespace XBMCRemoteRT.Helpers
         }
 
         /// <summary>
-        /// Returns path to a locally cached copy of the image. If the imagePath has not yet been cached, download is initiated but the Uri remains the same.
+        /// Returns path to a locally cached copy of the image. If the imagePath has not yet been cached, download is initiated but the URI remains the same.
         /// </summary>
         /// <param name="imagePath">Path on remote server to the resource. Usually begins with "image://"</param>
         /// <returns>Path to locally cached copy of the resource</returns>
@@ -79,20 +79,33 @@ namespace XBMCRemoteRT.Helpers
             imageUri = new Uri(storagePath, UriKind.Absolute);
 
             // TODO: Ideally, we've predicted all the possible images and cached them, but cache misses can be handled by simply downloading the image to the cache. Only a mild inconvenience for the user.
-            VerifyCache(storageFileName);
+            VerifyCache(GetRemoteUri(imagePath), storageFileName);
 
             return imageUri;
         }
 
-        private static async void VerifyCache(string filename)
+        /// <summary>
+        /// Ensure filename is cached. If not, download and save it to the cache location.
+        /// </summary>
+        /// <param name="imageUri">Remote location of the resource</param>
+        /// <param name="filename">Cached file name</param>
+        private static async void VerifyCache(Uri imageUri, string filename)
         {
             if (!(await IsFileCached(filename)))
             {
+
                 // TODO: cache miss. download and save.
+                Stream imageStream = await GetImageStream(imageUri);
+                WriteFile(imageStream, filename);
                 // TODO: Check file age and refresh cached image. Age is a bad way to do it though.
             }
         }
 
+        /// <summary>
+        /// Determine whether filename is cached.
+        /// </summary>
+        /// <param name="filename">File name</param>
+        /// <returns>Whether filename exists in the cache location</returns>
         private static async Task<bool> IsFileCached(string filename)
         {
 
@@ -146,6 +159,11 @@ namespace XBMCRemoteRT.Helpers
             return imageStream;
         }
 
+        /// <summary>
+        /// Write the contents of stream to filename in the cache location.
+        /// </summary>
+        /// <param name="stream">Content to be written to file</param>
+        /// <param name="filename">Name of the file to be written in cache location</param>
         private static async void WriteFile(Stream stream, string filename)
         {
 

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/CacheManager.cs
@@ -73,9 +73,8 @@ namespace XBMCRemoteRT.Helpers
         {
             Uri imageUri = null;
 
-            // TODO: Should each connection have its own cache? Two connections could have different images at the same path, but unlikely.
             string storageFileName = MD5Core.GetHashString(imagePath) + ".tmp";
-            string storagePath = Path.Combine(ApplicationData.Current.TemporaryFolder.Path, storageFileName);
+            string storagePath = Path.Combine(GetCacheFolder().Path, storageFileName);
             imageUri = new Uri(storagePath, UriKind.Absolute);
 
             // TODO: Ideally, we've predicted all the possible images and cached them, but cache misses can be handled by simply downloading the image to the cache. Only a mild inconvenience for the user.
@@ -110,7 +109,7 @@ namespace XBMCRemoteRT.Helpers
         {
 
             // Attempt to open file in app temp folder
-            StorageFolder parent = ApplicationData.Current.TemporaryFolder;
+            StorageFolder parent = GetCacheFolder();
             bool fileExists = false;
             try
             {
@@ -172,10 +171,11 @@ namespace XBMCRemoteRT.Helpers
             DataReader reader = new DataReader(inStream);
 
             // Prepare output file stream
-            StorageFolder parent = ApplicationData.Current.TemporaryFolder;
+            StorageFolder parent = GetCacheFolder();
             StorageFile file = null;
             try
             {
+                // TODO: Test overwriting of existing files
                 file = await parent.CreateFileAsync(filename, CreationCollisionOption.ReplaceExisting);
             }
             catch (Exception) {
@@ -196,6 +196,13 @@ namespace XBMCRemoteRT.Helpers
                 inStream.Dispose();
                 // TODO: Handle write task canceled exceptions, or prepare for corrupted images
             }
+        }
+
+        private static StorageFolder GetCacheFolder()
+        {
+            // Return folder to store cache files.
+            // One day this may return a different folder for each connection.
+            return ApplicationData.Current.TemporaryFolder;
         }
 
         public static async void ClearCacheAsync()

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/ConnectionManager.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/ConnectionManager.cs
@@ -52,7 +52,7 @@ namespace XBMCRemoteRT.Helpers
             request.Content = new StringContent(requestData);
             request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json"); //Required to be recognized as valid JSON request.
 
-            if (CurrentConnection.Password != String.Empty)
+            if (CurrentConnection.HasCredentials())
                 request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes(String.Format("{0}:{1}", CurrentConnection.Username, CurrentConnection.Password))));
             
             HttpResponseMessage response = await httpClient.SendAsync(request);

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/MD5.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/MD5.cs
@@ -1,0 +1,273 @@
+//Copyright (c) Microsoft Corporation.  All rights reserved.
+using System;
+using System.Text;
+
+// **************************************************************
+// * Raw implementation of the MD5 hash algorithm
+// * from RFC 1321.
+// *
+// * Written By: Reid Borsuk and Jenny Zheng
+// * Copyright (c) Microsoft Corporation.  All rights reserved.
+// **************************************************************
+
+// Simple struct for the (a,b,c,d) which is used to compute the mesage digest.    
+struct ABCDStruct 
+{
+    public uint A;
+    public uint B;
+    public uint C;
+    public uint D;
+}
+
+public sealed class MD5Core
+{    
+    //Prevent CSC from adding a default public constructor
+    private MD5Core() {}
+
+    public static byte[] GetHash(string input, Encoding encoding)
+    {
+        if (null == input)
+            throw new System.ArgumentNullException("input", "Unable to calculate hash over null input data");
+        if (null == encoding)
+            throw new System.ArgumentNullException("encoding", "Unable to calculate hash over a string without a default encoding. Consider using the GetHash(string) overload to use UTF8 Encoding");
+
+        byte[] target = encoding.GetBytes(input);
+
+        return GetHash(target);
+    }
+
+    public static byte[] GetHash(string input)
+    {
+        return GetHash(input, new UTF8Encoding());
+    }
+
+    public static string GetHashString(byte[] input)
+    {
+        if (null == input)
+            throw new System.ArgumentNullException("input", "Unable to calculate hash over null input data");
+
+        string retval = BitConverter.ToString(GetHash(input));
+        retval = retval.Replace("-", "");
+
+        return retval;
+    }
+
+    public static string GetHashString(string input, Encoding encoding)
+    {
+        if (null == input)
+            throw new System.ArgumentNullException("input", "Unable to calculate hash over null input data");
+        if (null == encoding)
+            throw new System.ArgumentNullException("encoding", "Unable to calculate hash over a string without a default encoding. Consider using the GetHashString(string) overload to use UTF8 Encoding");
+        
+        byte[] target = encoding.GetBytes(input);
+
+        return GetHashString(target);
+    }
+
+    public static string GetHashString(string input)
+    {
+        return GetHashString(input, new UTF8Encoding());
+    }
+
+    public static byte[] GetHash(byte[] input)
+    {
+        if (null == input)
+            throw new System.ArgumentNullException("input", "Unable to calculate hash over null input data");
+
+        //Intitial values defined in RFC 1321
+        ABCDStruct abcd = new ABCDStruct();
+        abcd.A = 0x67452301;
+        abcd.B = 0xefcdab89;
+        abcd.C = 0x98badcfe;
+        abcd.D = 0x10325476;
+
+        //We pass in the input array by block, the final block of data must be handled specialy for padding & length embeding
+        int startIndex = 0;
+        while (startIndex <= input.Length - 64)
+        {
+            MD5Core.GetHashBlock(input, ref abcd, startIndex);
+            startIndex += 64;
+        }
+        // The final data block. 
+        return MD5Core.GetHashFinalBlock(input, startIndex, input.Length - startIndex, abcd, (Int64)input.Length * 8);
+    }
+
+    internal static byte[] GetHashFinalBlock(byte[] input, int ibStart, int cbSize, ABCDStruct ABCD, Int64 len)
+    {
+        byte[] working = new byte[64];  
+        byte[] length = BitConverter.GetBytes(len);
+
+        //Padding is a single bit 1, followed by the number of 0s required to make size congruent to 448 modulo 512. Step 1 of RFC 1321  
+        //The CLR ensures that our buffer is 0-assigned, we don't need to explicitly set it. This is why it ends up being quicker to just
+        //use a temporary array rather then doing in-place assignment (5% for small inputs)
+        Array.Copy(input, ibStart, working, 0, cbSize);
+        working[cbSize] = 0x80;
+
+        //We have enough room to store the length in this chunk
+        if (cbSize < 56) 
+        {
+            Array.Copy(length, 0, working, 56, 8);
+            GetHashBlock(working, ref ABCD, 0);
+        }
+        else  //We need an aditional chunk to store the length
+        {
+            GetHashBlock(working, ref ABCD, 0);
+            //Create an entirely new chunk due to the 0-assigned trick mentioned above, to avoid an extra function call clearing the array
+            working = new byte[64];
+            Array.Copy(length, 0, working, 56, 8);
+            GetHashBlock(working, ref ABCD, 0);
+        }
+        byte[] output = new byte[16];
+        Array.Copy(BitConverter.GetBytes(ABCD.A), 0, output, 0, 4);
+        Array.Copy(BitConverter.GetBytes(ABCD.B), 0, output, 4, 4);
+        Array.Copy(BitConverter.GetBytes(ABCD.C), 0, output, 8, 4);
+        Array.Copy(BitConverter.GetBytes(ABCD.D), 0, output, 12, 4);
+        return output;
+    }
+
+    // Performs a single block transform of MD5 for a given set of ABCD inputs
+    /* If implementing your own hashing framework, be sure to set the initial ABCD correctly according to RFC 1321:
+    //    A = 0x67452301;
+    //    B = 0xefcdab89;
+    //    C = 0x98badcfe;
+    //    D = 0x10325476;
+    */
+    internal static void GetHashBlock(byte[] input, ref ABCDStruct ABCDValue, int ibStart)
+    {
+        uint[] temp = Converter(input, ibStart);
+        uint a = ABCDValue.A; 
+        uint b = ABCDValue.B;
+        uint c = ABCDValue.C;
+        uint d = ABCDValue.D;
+
+        a = r1(a, b, c, d, temp[0 ], 7,  0xd76aa478);
+        d = r1(d, a, b, c, temp[1 ], 12, 0xe8c7b756);
+        c = r1(c, d, a, b, temp[2 ], 17, 0x242070db);
+        b = r1(b, c, d, a, temp[3 ], 22, 0xc1bdceee);
+        a = r1(a, b, c, d, temp[4 ], 7,  0xf57c0faf);
+        d = r1(d, a, b, c, temp[5 ], 12, 0x4787c62a);
+        c = r1(c, d, a, b, temp[6 ], 17, 0xa8304613);
+        b = r1(b, c, d, a, temp[7 ], 22, 0xfd469501);
+        a = r1(a, b, c, d, temp[8 ], 7,  0x698098d8);
+        d = r1(d, a, b, c, temp[9 ], 12, 0x8b44f7af);
+        c = r1(c, d, a, b, temp[10], 17, 0xffff5bb1);
+        b = r1(b, c, d, a, temp[11], 22, 0x895cd7be);
+        a = r1(a, b, c, d, temp[12], 7,  0x6b901122);
+        d = r1(d, a, b, c, temp[13], 12, 0xfd987193);
+        c = r1(c, d, a, b, temp[14], 17, 0xa679438e);
+        b = r1(b, c, d, a, temp[15], 22, 0x49b40821);
+
+        a = r2(a, b, c, d, temp[1 ], 5,  0xf61e2562);
+        d = r2(d, a, b, c, temp[6 ], 9,  0xc040b340);
+        c = r2(c, d, a, b, temp[11], 14, 0x265e5a51);
+        b = r2(b, c, d, a, temp[0 ], 20, 0xe9b6c7aa);
+        a = r2(a, b, c, d, temp[5 ], 5,  0xd62f105d);
+        d = r2(d, a, b, c, temp[10], 9,  0x02441453);
+        c = r2(c, d, a, b, temp[15], 14, 0xd8a1e681);
+        b = r2(b, c, d, a, temp[4 ], 20, 0xe7d3fbc8);
+        a = r2(a, b, c, d, temp[9 ], 5,  0x21e1cde6);
+        d = r2(d, a, b, c, temp[14], 9,  0xc33707d6);
+        c = r2(c, d, a, b, temp[3 ], 14, 0xf4d50d87);
+        b = r2(b, c, d, a, temp[8 ], 20, 0x455a14ed);
+        a = r2(a, b, c, d, temp[13], 5,  0xa9e3e905);
+        d = r2(d, a, b, c, temp[2 ], 9,  0xfcefa3f8);
+        c = r2(c, d, a, b, temp[7 ], 14, 0x676f02d9);
+        b = r2(b, c, d, a, temp[12], 20, 0x8d2a4c8a);
+
+        a = r3(a, b, c, d, temp[5 ], 4,  0xfffa3942);
+        d = r3(d, a, b, c, temp[8 ], 11, 0x8771f681);
+        c = r3(c, d, a, b, temp[11], 16, 0x6d9d6122);
+        b = r3(b, c, d, a, temp[14], 23, 0xfde5380c);
+        a = r3(a, b, c, d, temp[1 ], 4,  0xa4beea44);
+        d = r3(d, a, b, c, temp[4 ], 11, 0x4bdecfa9);
+        c = r3(c, d, a, b, temp[7 ], 16, 0xf6bb4b60);
+        b = r3(b, c, d, a, temp[10], 23, 0xbebfbc70);
+        a = r3(a, b, c, d, temp[13], 4,  0x289b7ec6);
+        d = r3(d, a, b, c, temp[0 ], 11, 0xeaa127fa);
+        c = r3(c, d, a, b, temp[3 ], 16, 0xd4ef3085);
+        b = r3(b, c, d, a, temp[6 ], 23, 0x04881d05);
+        a = r3(a, b, c, d, temp[9 ], 4,  0xd9d4d039);
+        d = r3(d, a, b, c, temp[12], 11, 0xe6db99e5);
+        c = r3(c, d, a, b, temp[15], 16, 0x1fa27cf8);
+        b = r3(b, c, d, a, temp[2 ], 23, 0xc4ac5665);
+
+        a = r4(a, b, c, d, temp[0 ], 6,  0xf4292244);
+        d = r4(d, a, b, c, temp[7 ], 10, 0x432aff97);
+        c = r4(c, d, a, b, temp[14], 15, 0xab9423a7);
+        b = r4(b, c, d, a, temp[5 ], 21, 0xfc93a039);
+        a = r4(a, b, c, d, temp[12], 6,  0x655b59c3);
+        d = r4(d, a, b, c, temp[3 ], 10, 0x8f0ccc92);
+        c = r4(c, d, a, b, temp[10], 15, 0xffeff47d);
+        b = r4(b, c, d, a, temp[1 ], 21, 0x85845dd1);
+        a = r4(a, b, c, d, temp[8 ], 6,  0x6fa87e4f);
+        d = r4(d, a, b, c, temp[15], 10, 0xfe2ce6e0);
+        c = r4(c, d, a, b, temp[6 ], 15, 0xa3014314);
+        b = r4(b, c, d, a, temp[13], 21, 0x4e0811a1);
+        a = r4(a, b, c, d, temp[4 ], 6,  0xf7537e82);
+        d = r4(d, a, b, c, temp[11], 10, 0xbd3af235);
+        c = r4(c, d, a, b, temp[2 ], 15, 0x2ad7d2bb);
+        b = r4(b, c, d, a, temp[9 ], 21, 0xeb86d391);
+
+        ABCDValue.A = unchecked(a + ABCDValue.A);
+        ABCDValue.B = unchecked(b + ABCDValue.B);
+        ABCDValue.C = unchecked(c + ABCDValue.C);
+        ABCDValue.D = unchecked(d + ABCDValue.D);
+        return; 
+    }
+
+    //Manually unrolling these equations nets us a 20% performance improvement
+    private static uint r1(uint a, uint b, uint c, uint d, uint x, int s, uint t)
+    {
+        //                  (b + LSR((a + F(b, c, d) + x + t), s))
+        //F(x, y, z)        ((x & y) | ((x ^ 0xFFFFFFFF) & z))
+        return unchecked(b + LSR((a + ((b & c) | ((b ^ 0xFFFFFFFF) & d)) + x + t), s));
+    }
+
+    private static uint r2(uint a, uint b, uint c, uint d, uint x, int s, uint t)
+    {
+        //                  (b + LSR((a + G(b, c, d) + x + t), s))
+        //G(x, y, z)        ((x & z) | (y & (z ^ 0xFFFFFFFF)))
+        return unchecked(b + LSR((a + ((b & d) | (c & (d ^ 0xFFFFFFFF))) + x + t), s));
+    }
+
+    private static uint r3(uint a, uint b, uint c, uint d, uint x, int s, uint t)
+    {
+        //                  (b + LSR((a + H(b, c, d) + k + i), s))
+        //H(x, y, z)        (x ^ y ^ z)
+        return unchecked(b + LSR((a + (b ^ c ^ d) + x + t), s));
+    }
+
+    private static uint r4(uint a, uint b, uint c, uint d, uint x, int s, uint t)
+    {
+        //                  (b + LSR((a + I(b, c, d) + k + i), s))
+        //I(x, y, z)        (y ^ (x | (z ^ 0xFFFFFFFF)))
+        return unchecked(b + LSR((a + (c ^ (b | (d ^ 0xFFFFFFFF))) + x + t), s));
+    }
+
+    // Implementation of left rotate
+    // s is an int instead of a uint becuase the CLR requires the argument passed to >>/<< is of 
+    // type int. Doing the demoting inside this function would add overhead.
+    private static uint LSR(uint i, int s)
+    {
+        return ((i << s) | (i >> (32-s)));
+    }
+
+    //Convert input array into array of UInts
+    private static uint[] Converter(byte[] input, int ibStart)
+    {
+        if(null == input)
+            throw new System.ArgumentNullException("input", "Unable convert null array to array of uInts");
+        
+        uint[] result = new uint[16];
+        
+        for (int i = 0; i < 16; i++)
+        {
+            result[i] = (uint)input[ibStart + i * 4];
+            result[i] += (uint)input[ibStart + i * 4 + 1] << 8;
+            result[i] += (uint)input[ibStart + i * 4 + 2] << 16;
+            result[i] += (uint)input[ibStart + i * 4 + 3] << 24;
+        }
+       
+        return result;
+    }
+}

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Models/ConnectionItem.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Models/ConnectionItem.cs
@@ -91,7 +91,13 @@ namespace XBMCRemoteRT.Models
                     NotifyPropertyChanged("Password");
                 }
             }
-        }      
+        }
+
+        public bool HasCredentials()
+        {
+            return password != null
+                && password != string.Empty;
+        }
     }
 }
 

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/RPCWrappers/JSONRPC.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/RPCWrappers/JSONRPC.cs
@@ -31,7 +31,7 @@ namespace XBMCRemoteRT.RPCWrappers
             request.Content = new StringContent(requestData);
             request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json"); //Required to be recognized as valid JSON request.
 
-            if (connectionItem.Password != String.Empty)
+            if (connectionItem.HasCredentials())
                 request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes(String.Format("{0}:{1}", connectionItem.Username, connectionItem.Password))));
 
             HttpResponseMessage response = await httpClient.SendAsync(request);

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/XBMCRemoteRT.Shared.projitems
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/XBMCRemoteRT.Shared.projitems
@@ -35,6 +35,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\FeedbackHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\GlobalVariables.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\GroupingHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\MD5.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\PlayerHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\SettingsHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Audio\Album.cs" />

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/XBMCRemoteRT.Shared.projitems
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/XBMCRemoteRT.Shared.projitems
@@ -30,6 +30,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Converters\SpeedToSymbolIconConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\StringToImageBrushConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ToUpperConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\CacheManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ConnectionManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\FeedbackHelper.cs" />

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/MainPage.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/MainPage.xaml
@@ -52,6 +52,24 @@
             </ListView>
         </Grid>
         <ProgressRing x:Name="ProgressRing" IsActive="False" Grid.RowSpan="10" />
+        <Grid x:Name="CacheProgressGrid"
+              DataContext="{Binding ConnectionItems}"
+              Visibility="Collapsed"
+              Grid.RowSpan="10">
+            <Grid.Background>
+                <SolidColorBrush Color="{StaticResource PhoneBackgroundColor}" Opacity="0.8"/>
+            </Grid.Background>
+            <StackPanel Margin="12,0" VerticalAlignment="Center">
+                <TextBlock HorizontalAlignment="Center"
+                           Margin="0,0,0,6"
+                           FontSize="18"
+                           Opacity="0.6">
+                    <Run Text="preparing library... "/>
+                </TextBlock>
+                <ProgressBar x:Name="CacheProgressBar"
+                             Value="0"/>
+            </StackPanel>
+        </Grid>
     </Grid>
     
     <Page.BottomAppBar>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/MainPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/MainPage.xaml.cs
@@ -179,6 +179,15 @@ namespace XBMCRemoteRT
             {
                 ConnectionManager.CurrentConnection = connectionItem;
                 SettingsHelper.SetValue("RecentServerIP", connectionItem.IpAddress);
+
+                // Update cache
+                IAsyncOperationWithProgress<int, int> cacheOperation = CacheManager.UpdateCacheAsync();
+                cacheOperation.Progress = (result, progress) =>
+                {
+                    // TODO: Indicate progress to user
+                };
+                await cacheOperation;
+
                 Frame.Navigate(typeof(CoverPage));
             }
             else

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/MainPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/MainPage.xaml.cs
@@ -34,7 +34,7 @@ namespace XBMCRemoteRT
     /// </summary>
     public sealed partial class MainPage : Page
     {
-        private enum PageStates { Ready, Connecting }
+        private enum PageStates { Ready, Connecting, Caching }
 
         private NavigationHelper navigationHelper;
         private ObservableDictionary defaultViewModel = new ObservableDictionary();
@@ -180,13 +180,19 @@ namespace XBMCRemoteRT
                 ConnectionManager.CurrentConnection = connectionItem;
                 SettingsHelper.SetValue("RecentServerIP", connectionItem.IpAddress);
 
-                // Update cache
-                IAsyncOperationWithProgress<int, int> cacheOperation = CacheManager.UpdateCacheAsync();
-                cacheOperation.Progress = (result, progress) =>
+                if (connectionItem.HasCredentials())
                 {
-                    // TODO: Indicate progress to user
-                };
-                await cacheOperation;
+                    // Update cache
+                    SetPageState(PageStates.Caching);
+                    CacheProgressBar.Value = 0;
+                    IAsyncOperationWithProgress<int, int> cacheOperation = CacheManager.UpdateCacheAsync();
+                    cacheOperation.Progress = (result, progress) =>
+                    {
+                        // Indicate progress to user
+                        CacheProgressBar.Value = progress;
+                    };
+                    await cacheOperation;
+                }
 
                 Frame.Navigate(typeof(CoverPage));
             }
@@ -205,12 +211,21 @@ namespace XBMCRemoteRT
                 ConnectionsListView.IsEnabled = false;
                 BottomAppBar.Visibility = Visibility.Collapsed;
                 ProgressRing.IsActive = true;
+                CacheProgressGrid.Visibility = Visibility.Collapsed;
+            }
+            else if (pageState == PageStates.Caching)
+            {
+                ConnectionsListView.IsEnabled = false;
+                BottomAppBar.Visibility = Visibility.Collapsed;
+                ProgressRing.IsActive = false;
+                CacheProgressGrid.Visibility = Visibility.Visible;
             }
             else
             {
                 ConnectionsListView.IsEnabled = true;
                 BottomAppBar.Visibility = Visibility.Visible;
                 ProgressRing.IsActive = false;
+                CacheProgressGrid.Visibility = Visibility.Collapsed;
             }
         }
 

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
@@ -209,7 +209,8 @@
                         <TextBlock Text="TEMPORARY FILES" 
                                    Style="{StaticResource ParagraphHeaderTextStyle}" 
                                    Pivot.SlideInAnimationGroup="GroupOne"/>
-                        <Button Content="refresh" 
+                        <Button x:Name="CacheRefreshButton" 
+                                Content="refresh" 
                                 Tapped="CacheRefreshButton_Tapped"
                                 HorizontalAlignment="Stretch" 
                                 Margin="0,6,0,0" 

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
@@ -268,41 +268,43 @@
                     <StackPanel>
                         <TextBlock Text="AUTOCONNECT" Style="{StaticResource ParagraphHeaderTextStyle}" Pivot.SlideInAnimationGroup="GroupOne"/>
                         <ToggleSwitch x:Name="AutoconnectToggle" Header="connect automatically on startup" Margin="0,6,0,0" Pivot.SlideInAnimationGroup="GroupTwo" />
-                        <TextBlock Text="TEMPORARY FILES" 
-                                   Style="{StaticResource ParagraphHeaderTextStyle}" 
-                                   Pivot.SlideInAnimationGroup="GroupOne"/>
-                        <Button x:Name="CacheRefreshButton" 
-                                Content="refresh" 
-                                Tapped="CacheRefreshButton_Tapped"
-                                HorizontalAlignment="Stretch" 
-                                Margin="0,6,0,0"
-                                Pivot.SlideInAnimationGroup="GroupTwo"/>
-                        <Grid>
-                            <TextBlock x:Name="textBlock" Text="Kodi Assist saves some images on your phone so you can access your library more quickly. If things like album art and movie posters have changed, you can refresh to see them right away."
-                                   TextWrapping="Wrap"
-                                   FontSize="16"
-                                   Opacity=".6"
-                                   Pivot.SlideInAnimationGroup="GroupThree" RenderTransformOrigin="0.5,0.5">
-                            	<TextBlock.RenderTransform>
-                            		<CompositeTransform/>
-                            	</TextBlock.RenderTransform>
-                            </TextBlock>
-                            <StackPanel x:Name="stackPanel" VerticalAlignment="Top"
-                                        Margin="0,2,0,0" 
-                                        Opacity="0" 
-                                        Pivot.SlideInAnimationGroup="GroupThree"
-                                        RenderTransformOrigin="0.5,0.5">
-                            	<StackPanel.RenderTransform>
-                            		<CompositeTransform/>
-                            	</StackPanel.RenderTransform>
-                                <ProgressBar x:Name="CacheRefreshProgressBar"
-                                             Value="0"/>
-                                <TextBlock Text="Just a moment..."
-                                           Margin="0,6,0,0"
-                                           FontSize="16"
-                                           Opacity=".6"/>
-                            </StackPanel>
-                        </Grid>
+                        <StackPanel x:Name="CacheRefreshPanel">
+                            <TextBlock Text="TEMPORARY FILES"
+                                       Style="{StaticResource ParagraphHeaderTextStyle}" 
+                                       Pivot.SlideInAnimationGroup="GroupOne"/>
+                            <Button x:Name="CacheRefreshButton"
+                                    Content="refresh"
+                                    Tapped="CacheRefreshButton_Tapped"
+                                    HorizontalAlignment="Stretch"
+                                    Margin="0,6,0,0"
+                                    Pivot.SlideInAnimationGroup="GroupTwo"/>
+                            <Grid>
+                                <TextBlock x:Name="textBlock" Text="Kodi Assist saves some images on your phone so you can access your library more quickly. If things like album art and movie posters have changed, you can refresh to see them right away."
+                                       TextWrapping="Wrap"
+                                       FontSize="16"
+                                       Opacity=".6"
+                                       Pivot.SlideInAnimationGroup="GroupThree" RenderTransformOrigin="0.5,0.5">
+                                    <TextBlock.RenderTransform>
+                                        <CompositeTransform/>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
+                                <StackPanel x:Name="stackPanel" VerticalAlignment="Top"
+                                            Margin="0,2,0,0"
+                                            Opacity="0"
+                                            Pivot.SlideInAnimationGroup="GroupThree"
+                                            RenderTransformOrigin="0.5,0.5">
+                                    <StackPanel.RenderTransform>
+                                        <CompositeTransform/>
+                                    </StackPanel.RenderTransform>
+                                    <ProgressBar x:Name="CacheRefreshProgressBar"
+                                                 Value="0"/>
+                                    <TextBlock Text="Just a moment..."
+                                               Margin="0,6,0,0"
+                                               FontSize="16"
+                                               Opacity=".6"/>
+                                </StackPanel>
+                            </Grid>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
             </PivotItem>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
@@ -206,6 +206,19 @@
                     <StackPanel>
                         <TextBlock Text="AUTOCONNECT" Style="{StaticResource ParagraphHeaderTextStyle}" Pivot.SlideInAnimationGroup="GroupOne"/>
                         <ToggleSwitch x:Name="AutoconnectToggle" Header="connect automatically on startup" Margin="0,6,0,0" Pivot.SlideInAnimationGroup="GroupTwo" />
+                        <TextBlock Text="TEMPORARY FILES" 
+                                   Style="{StaticResource ParagraphHeaderTextStyle}" 
+                                   Pivot.SlideInAnimationGroup="GroupOne"/>
+                        <Button Content="refresh" 
+                                Tapped="CacheRefreshButton_Tapped"
+                                HorizontalAlignment="Stretch" 
+                                Margin="0,6,0,0" 
+                                Pivot.SlideInAnimationGroup="GroupTwo"/>
+                        <TextBlock Text="Kodi Assist saves some images on your phone so you can access your library more quickly. If things like album art and movie posters have changed, you can refresh to see them right away."
+                                   TextWrapping="Wrap"
+                                   FontSize="16"
+                                   Opacity=".6"
+                                   Pivot.SlideInAnimationGroup="GroupTwo"/>
                     </StackPanel>
                 </ScrollViewer>
             </PivotItem>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
@@ -7,122 +7,184 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-	<Page.Resources>
-		<SolidColorBrush x:Key="CheckBoxBackgroundThemeBrush" Color="Transparent"/>
-		<Thickness x:Key="PhoneBorderThickness">2.5</Thickness>
-		<x:Double x:Key="TextStyleLargeFontSize">18.14</x:Double>
-		<FontFamily x:Key="PhoneFontFamilyNormal">Segoe WP</FontFamily>
-		<SolidColorBrush x:Key="CheckBoxDisabledBackgroundThemeBrush" Color="Transparent"/>
-		<Style x:Key="RoundButtonCheckBoxStyle" TargetType="CheckBox">
-			<Setter Property="Background" Value="{ThemeResource CheckBoxBackgroundThemeBrush}"/>
-			<Setter Property="BorderBrush" Value="{ThemeResource CheckBoxBorderThemeBrush}"/>
-			<Setter Property="BorderThickness" Value="{ThemeResource PhoneBorderThickness}"/>
-			<Setter Property="FontSize" Value="{ThemeResource TextStyleLargeFontSize}"/>
-			<Setter Property="FontFamily" Value="{ThemeResource PhoneFontFamilyNormal}"/>
-			<Setter Property="HorizontalContentAlignment" Value="Left"/>
-			<Setter Property="VerticalContentAlignment" Value="Top"/>
-			<Setter Property="HorizontalAlignment" Value="Left"/>
+    <Page.Resources>
+        <SolidColorBrush x:Key="CheckBoxBackgroundThemeBrush" Color="Transparent"/>
+        <Thickness x:Key="PhoneBorderThickness">2.5</Thickness>
+        <x:Double x:Key="TextStyleLargeFontSize">18.14</x:Double>
+        <FontFamily x:Key="PhoneFontFamilyNormal">Segoe WP</FontFamily>
+        <SolidColorBrush x:Key="CheckBoxDisabledBackgroundThemeBrush" Color="Transparent"/>
+        <Style x:Key="RoundButtonCheckBoxStyle" TargetType="CheckBox">
+            <Setter Property="Background" Value="{ThemeResource CheckBoxBackgroundThemeBrush}"/>
+            <Setter Property="BorderBrush" Value="{ThemeResource CheckBoxBorderThemeBrush}"/>
+            <Setter Property="BorderThickness" Value="{ThemeResource PhoneBorderThickness}"/>
+            <Setter Property="FontSize" Value="{ThemeResource TextStyleLargeFontSize}"/>
+            <Setter Property="FontFamily" Value="{ThemeResource PhoneFontFamilyNormal}"/>
+            <Setter Property="HorizontalContentAlignment" Value="Left"/>
+            <Setter Property="VerticalContentAlignment" Value="Top"/>
+            <Setter Property="HorizontalAlignment" Value="Left"/>
             <Setter Property="VerticalAlignment" Value="Top"/>
             <Setter Property="Margin" Value="-55,0"/>
             <Setter Property="Template">
-				<Setter.Value>
-					<ControlTemplate TargetType="CheckBox">
-						<Grid Background="Transparent" Width="50">
-							<VisualStateManager.VisualStateGroups>
-								<VisualStateGroup x:Name="CommonStates">
-									<VisualStateGroup.Transitions>
-										<VisualTransition From="Pressed" To="PointerOver">
-											<Storyboard>
-												<PointerUpThemeAnimation Storyboard.TargetName="Grid"/>
-											</Storyboard>
-										</VisualTransition>
-										<VisualTransition From="PointerOver" To="Normal">
-											<Storyboard>
-												<PointerUpThemeAnimation Storyboard.TargetName="Grid"/>
-											</Storyboard>
-										</VisualTransition>
-										<VisualTransition From="Pressed" To="Normal">
-											<Storyboard>
-												<PointerUpThemeAnimation Storyboard.TargetName="Grid"/>
-											</Storyboard>
-										</VisualTransition>
-									</VisualStateGroup.Transitions>
-									<VisualState x:Name="Normal"/>
-									<VisualState x:Name="MouseOver"/>
-									<VisualState x:Name="PointerOver"/>
-									<VisualState x:Name="Pressed">
-										<Storyboard>
-											<PointerDownThemeAnimation Storyboard.TargetName="Grid"/>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background" Storyboard.TargetName="CheckBackground">
-												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxPressedBackgroundThemeBrush}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill" Storyboard.TargetName="CheckGlyph">
-												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxPressedForegroundThemeBrush}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill" Storyboard.TargetName="NormalRectangle">
-												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxPressedBackgroundThemeBrush}"/>
-											</ObjectAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualState>
-									<VisualState x:Name="Disabled">
-										<Storyboard>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="BorderBrush" Storyboard.TargetName="CheckBackground">
-												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxDisabledBorderThemeBrush}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill" Storyboard.TargetName="CheckGlyph">
-												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxDisabledForegroundThemeBrush}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill" Storyboard.TargetName="NormalRectangle">
-												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxDisabledBackgroundThemeBrush}"/>
-											</ObjectAnimationUsingKeyFrames>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground" Storyboard.TargetName="ContentPresenter">
-												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxDisabledForegroundThemeBrush}"/>
-											</ObjectAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualState>
-								</VisualStateGroup>
-								<VisualStateGroup x:Name="CheckStates">
-									<VisualState x:Name="Checked">
-										<Storyboard>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility" Storyboard.TargetName="CheckGlyph">
-												<DiscreteObjectKeyFrame KeyTime="0" Value="Visible"/>
-											</ObjectAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualState>
-									<VisualState x:Name="Unchecked"/>
-									<VisualState x:Name="Indeterminate">
-										<Storyboard>
-											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility" Storyboard.TargetName="NormalRectangle">
-												<DiscreteObjectKeyFrame KeyTime="0" Value="Visible"/>
-											</ObjectAnimationUsingKeyFrames>
-										</Storyboard>
-									</VisualState>
-								</VisualStateGroup>
-							</VisualStateManager.VisualStateGroups>
-							<Grid x:Name="Grid">
-								<Grid.RowDefinitions>
-									<RowDefinition Height="auto"/>
-									<RowDefinition Height="25.5"/>									
-								</Grid.RowDefinitions>
-								<Grid Grid.Row="0" HorizontalAlignment="Center" Height="50" Margin="0,0,0,24" Width="50">
-                            <Ellipse x:Name="Ellipse" Fill="{ThemeResource AppBarItemBackgroundThemeBrush}" Height="50" Stroke="{ThemeResource AppBarItemForegroundThemeBrush}" StrokeThickness="2" UseLayoutRounding="False" Width="50"/>
-                            <Grid x:Name="ContentRoot" Background="Transparent">
-                                <ContentPresenter x:Name="ContentPresenter" AutomationProperties.AccessibilityView="Raw" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Foreground="{TemplateBinding Foreground}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+                <Setter.Value>
+                    <ControlTemplate TargetType="CheckBox">
+                        <Grid Background="Transparent" Width="50">
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualStateGroup.Transitions>
+                                        <VisualTransition From="Pressed" To="PointerOver">
+                                            <Storyboard>
+                                                <PointerUpThemeAnimation Storyboard.TargetName="Grid"/>
+                                            </Storyboard>
+                                        </VisualTransition>
+                                        <VisualTransition From="PointerOver" To="Normal">
+                                            <Storyboard>
+                                                <PointerUpThemeAnimation Storyboard.TargetName="Grid"/>
+                                            </Storyboard>
+                                        </VisualTransition>
+                                        <VisualTransition From="Pressed" To="Normal">
+                                            <Storyboard>
+                                                <PointerUpThemeAnimation Storyboard.TargetName="Grid"/>
+                                            </Storyboard>
+                                        </VisualTransition>
+                                    </VisualStateGroup.Transitions>
+                                    <VisualState x:Name="Normal"/>
+                                    <VisualState x:Name="MouseOver"/>
+                                    <VisualState x:Name="PointerOver"/>
+                                    <VisualState x:Name="Pressed">
+                                        <Storyboard>
+                                            <PointerDownThemeAnimation Storyboard.TargetName="Grid"/>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background" Storyboard.TargetName="CheckBackground">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxPressedBackgroundThemeBrush}"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill" Storyboard.TargetName="CheckGlyph">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxPressedForegroundThemeBrush}"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill" Storyboard.TargetName="NormalRectangle">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxPressedBackgroundThemeBrush}"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="Disabled">
+                                        <Storyboard>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="BorderBrush" Storyboard.TargetName="CheckBackground">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxDisabledBorderThemeBrush}"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill" Storyboard.TargetName="CheckGlyph">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxDisabledForegroundThemeBrush}"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Fill" Storyboard.TargetName="NormalRectangle">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxDisabledBackgroundThemeBrush}"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground" Storyboard.TargetName="ContentPresenter">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxDisabledForegroundThemeBrush}"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualState>
+                                </VisualStateGroup>
+                                <VisualStateGroup x:Name="CheckStates">
+                                    <VisualState x:Name="Checked">
+                                        <Storyboard>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility" Storyboard.TargetName="CheckGlyph">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="Visible"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualState>
+                                    <VisualState x:Name="Unchecked"/>
+                                    <VisualState x:Name="Indeterminate">
+                                        <Storyboard>
+                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility" Storyboard.TargetName="NormalRectangle">
+                                                <DiscreteObjectKeyFrame KeyTime="0" Value="Visible"/>
+                                            </ObjectAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualState>
+                                </VisualStateGroup>
+                            </VisualStateManager.VisualStateGroups>
+                            <Grid x:Name="Grid">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="auto"/>
+                                    <RowDefinition Height="25.5"/>
+                                </Grid.RowDefinitions>
+                                <Grid Grid.Row="0" HorizontalAlignment="Center" Height="50" Margin="0,0,0,24" Width="50">
+                                    <Ellipse x:Name="Ellipse" Fill="{ThemeResource AppBarItemBackgroundThemeBrush}" Height="50" Stroke="{ThemeResource AppBarItemForegroundThemeBrush}" StrokeThickness="2" UseLayoutRounding="False" Width="50"/>
+                                    <Grid x:Name="ContentRoot" Background="Transparent">
+                                        <ContentPresenter x:Name="ContentPresenter" AutomationProperties.AccessibilityView="Raw" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Foreground="{TemplateBinding Foreground}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+                                    </Grid>
+                                </Grid>
+                                <Grid Grid.Row="1" HorizontalAlignment="Center">
+                                    <Border x:Name="CheckBackground" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" HorizontalAlignment="Left" Height="25.5" IsHitTestVisible="False" VerticalAlignment="Center" Width="25.5"/>
+                                    <Rectangle x:Name="NormalRectangle" Fill="{ThemeResource CheckBoxBackgroundThemeBrush}" HorizontalAlignment="Center" Height="13" IsHitTestVisible="False" Visibility="Collapsed" VerticalAlignment="Center" Width="13"/>
+                                    <Path x:Name="CheckGlyph" Data="M0,123 L39,93 L124,164 L256,18 L295,49 L124,240 z" Fill="{ThemeResource CheckBoxForegroundThemeBrush}" FlowDirection="LeftToRight" HorizontalAlignment="Center" Height="17" IsHitTestVisible="False" Stretch="Fill" StrokeThickness="2.5" StrokeLineJoin="Round" Visibility="Collapsed" VerticalAlignment="Center" Width="18.5"/>
+                                </Grid>
+                                <!--<ContentPresenter x:Name="ContentPresenter" AutomationProperties.AccessibilityView="Raw" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Grid.Column="1" Foreground="{TemplateBinding Foreground}" FontWeight="Normal" FontSize="{ThemeResource TextStyleLargeFontSize}" FontFamily="{ThemeResource PhoneFontFamilyNormal}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>-->
                             </Grid>
                         </Grid>
-								<Grid Grid.Row="1" HorizontalAlignment="Center">
-									<Border x:Name="CheckBackground" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" HorizontalAlignment="Left" Height="25.5" IsHitTestVisible="False" VerticalAlignment="Center" Width="25.5"/>
-									<Rectangle x:Name="NormalRectangle" Fill="{ThemeResource CheckBoxBackgroundThemeBrush}" HorizontalAlignment="Center" Height="13" IsHitTestVisible="False" Visibility="Collapsed" VerticalAlignment="Center" Width="13"/>
-									<Path x:Name="CheckGlyph" Data="M0,123 L39,93 L124,164 L256,18 L295,49 L124,240 z" Fill="{ThemeResource CheckBoxForegroundThemeBrush}" FlowDirection="LeftToRight" HorizontalAlignment="Center" Height="17" IsHitTestVisible="False" Stretch="Fill" StrokeThickness="2.5" StrokeLineJoin="Round" Visibility="Collapsed" VerticalAlignment="Center" Width="18.5"/>
-								</Grid>
-								<!--<ContentPresenter x:Name="ContentPresenter" AutomationProperties.AccessibilityView="Raw" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" Grid.Column="1" Foreground="{TemplateBinding Foreground}" FontWeight="Normal" FontSize="{ThemeResource TextStyleLargeFontSize}" FontFamily="{ThemeResource PhoneFontFamilyNormal}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>-->
-							</Grid>
-						</Grid>
-					</ControlTemplate>
-				</Setter.Value>
-			</Setter>
-		</Style>
-	</Page.Resources>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Storyboard x:Name="RefreshStart">
+        	<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)" Storyboard.TargetName="textBlock">
+        		<EasingDoubleKeyFrame KeyTime="0" Value="0"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="96">
+        			<EasingDoubleKeyFrame.EasingFunction>
+        				<QuarticEase EasingMode="EaseIn"/>
+        			</EasingDoubleKeyFrame.EasingFunction>
+        		</EasingDoubleKeyFrame>
+        	</DoubleAnimationUsingKeyFrames>
+        	<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)" Storyboard.TargetName="stackPanel">
+        		<EasingDoubleKeyFrame KeyTime="0" Value="96"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="96"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="31.0952"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0">
+        			<EasingDoubleKeyFrame.EasingFunction>
+        				<BackEase EasingMode="EaseOut" Amplitude="0.5"/>
+        			</EasingDoubleKeyFrame.EasingFunction>
+        		</EasingDoubleKeyFrame>
+        	</DoubleAnimationUsingKeyFrames>
+        	<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="textBlock">
+        		<EasingDoubleKeyFrame KeyTime="0" Value="0.6"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="0.6"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
+        	</DoubleAnimationUsingKeyFrames>
+        	<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="stackPanel">
+        		<EasingDoubleKeyFrame KeyTime="0" Value="0"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="0"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="1"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="1"/>
+        	</DoubleAnimationUsingKeyFrames>
+        </Storyboard>
+        <Storyboard x:Name="RefreshEnd">
+        	<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)" Storyboard.TargetName="stackPanel">
+        		<EasingDoubleKeyFrame KeyTime="0" Value="0"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="96">
+        			<EasingDoubleKeyFrame.EasingFunction>
+        				<QuarticEase EasingMode="EaseIn"/>
+        			</EasingDoubleKeyFrame.EasingFunction>
+        		</EasingDoubleKeyFrame>
+        	</DoubleAnimationUsingKeyFrames>
+        	<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="stackPanel">
+        		<EasingDoubleKeyFrame KeyTime="0" Value="1"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="1"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
+        	</DoubleAnimationUsingKeyFrames>
+        	<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)" Storyboard.TargetName="textBlock">
+        		<EasingDoubleKeyFrame KeyTime="0" Value="96"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="96"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="31.0952"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0">
+        			<EasingDoubleKeyFrame.EasingFunction>
+        				<BackEase EasingMode="EaseOut" Amplitude="0.5"/>
+        			</EasingDoubleKeyFrame.EasingFunction>
+        		</EasingDoubleKeyFrame>
+        	</DoubleAnimationUsingKeyFrames>
+        	<DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="textBlock">
+        		<EasingDoubleKeyFrame KeyTime="0" Value="0"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="0"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="0.6"/>
+        		<EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0.6"/>
+        	</DoubleAnimationUsingKeyFrames>
+        </Storyboard>
+    </Page.Resources>
 
     <Grid x:Name="LayoutRoot">
 
@@ -197,7 +259,7 @@
                     </StackPanel>
                 </ScrollViewer>
             </PivotItem>
-            
+
             <PivotItem>
                 <PivotItem.Header>
                     <TextBlock Text="CONNECTIONS" Style="{StaticResource PageHeaderTextStyle}"/>
@@ -213,13 +275,33 @@
                                 Content="refresh" 
                                 Tapped="CacheRefreshButton_Tapped"
                                 HorizontalAlignment="Stretch" 
-                                Margin="0,6,0,0" 
+                                Margin="0,6,0,0"
                                 Pivot.SlideInAnimationGroup="GroupTwo"/>
-                        <TextBlock Text="Kodi Assist saves some images on your phone so you can access your library more quickly. If things like album art and movie posters have changed, you can refresh to see them right away."
+                        <Grid>
+                            <TextBlock x:Name="textBlock" Text="Kodi Assist saves some images on your phone so you can access your library more quickly. If things like album art and movie posters have changed, you can refresh to see them right away."
                                    TextWrapping="Wrap"
                                    FontSize="16"
                                    Opacity=".6"
-                                   Pivot.SlideInAnimationGroup="GroupTwo"/>
+                                   Pivot.SlideInAnimationGroup="GroupTwo" RenderTransformOrigin="0.5,0.5">
+                            	<TextBlock.RenderTransform>
+                            		<CompositeTransform/>
+                            	</TextBlock.RenderTransform>
+                            </TextBlock>
+                            <StackPanel x:Name="stackPanel" VerticalAlignment="Top"
+                                        Margin="0,2,0,0" 
+                                        Opacity="0" 
+                                        RenderTransformOrigin="0.5,0.5">
+                            	<StackPanel.RenderTransform>
+                            		<CompositeTransform/>
+                            	</StackPanel.RenderTransform>
+                                <ProgressBar x:Name="CacheRefreshProgressBar"
+                                             Value="0"/>
+                                <TextBlock Text="Just a moment..."
+                                           Margin="0,6,0,0"
+                                           FontSize="16"
+                                           Opacity=".6"/>
+                            </StackPanel>
+                        </Grid>
                     </StackPanel>
                 </ScrollViewer>
             </PivotItem>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
@@ -244,13 +244,13 @@
                         </StackPanel >
 
                         <TextBlock Text="SKIP + JUMP" Style="{StaticResource ParagraphHeaderTextStyle}" Margin="0,24,0,0" Pivot.SlideInAnimationGroup="GroupOne" />
-                        <ComboBox x:Name="ForwardComboBox" Header="what does forward do" Margin="0,12,0,0">
+                        <ComboBox x:Name="ForwardComboBox" Header="what does forward do" Margin="0,12,0,0" Pivot.SlideInAnimationGroup="GroupTwo">
                             <ComboBoxItem Content="increase speed"/>
                             <ComboBoxItem Content="small jump forward"/>
                             <ComboBoxItem Content="big jump forward"/>
                         </ComboBox>
 
-                        <ComboBox x:Name="BackwardComboBox" Header="what does backward do" Margin="0,12,0,0">
+                        <ComboBox x:Name="BackwardComboBox" Header="what does backward do" Margin="0,12,0,0" Pivot.SlideInAnimationGroup="GroupTwo">
                             <ComboBoxItem Content="decrease speed"/>
                             <ComboBoxItem Content="small jump backward"/>
                             <ComboBoxItem Content="big jump backward"/>
@@ -282,7 +282,7 @@
                                    TextWrapping="Wrap"
                                    FontSize="16"
                                    Opacity=".6"
-                                   Pivot.SlideInAnimationGroup="GroupTwo" RenderTransformOrigin="0.5,0.5">
+                                   Pivot.SlideInAnimationGroup="GroupThree" RenderTransformOrigin="0.5,0.5">
                             	<TextBlock.RenderTransform>
                             		<CompositeTransform/>
                             	</TextBlock.RenderTransform>
@@ -290,6 +290,7 @@
                             <StackPanel x:Name="stackPanel" VerticalAlignment="Top"
                                         Margin="0,2,0,0" 
                                         Opacity="0" 
+                                        Pivot.SlideInAnimationGroup="GroupThree"
                                         RenderTransformOrigin="0.5,0.5">
                             	<StackPanel.RenderTransform>
                             		<CompositeTransform/>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
@@ -191,6 +191,8 @@ namespace XBMCRemoteRT.Pages
 
         private async void CacheRefreshButton_Tapped(object sender, TappedRoutedEventArgs e)
         {
+            CacheRefreshButton.IsEnabled = false;
+
             // Clear the cache
             IAsyncOperationWithProgress<int, int> clearOperation = CacheManager.ClearCacheAsync();
             clearOperation.Progress = (result, progress) => {
@@ -201,6 +203,8 @@ namespace XBMCRemoteRT.Pages
             // Immediately load the cache. We don't want the user to see empty
             // and partially loaded images from cache misses.
             await CacheManager.InitCacheAsync();
+
+            CacheRefreshButton.IsEnabled = true;
         }
 
         #region NavigationHelper registration

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
@@ -202,7 +202,12 @@ namespace XBMCRemoteRT.Pages
 
             // Immediately load the cache. We don't want the user to see empty
             // and partially loaded images from cache misses.
-            await CacheManager.InitCacheAsync();
+            IAsyncOperationWithProgress<int, int> initOperation = CacheManager.InitCacheAsync();
+            initOperation.Progress = (result, progress) =>
+            {
+                // Progress is int 0 to 100
+            };
+            await initOperation;
 
             CacheRefreshButton.IsEnabled = true;
         }

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
@@ -37,6 +37,11 @@ namespace XBMCRemoteRT.Pages
             this.navigationHelper = new NavigationHelper(this);
             this.navigationHelper.LoadState += this.NavigationHelper_LoadState;
             this.navigationHelper.SaveState += this.NavigationHelper_SaveState;
+
+            // The cache refresh task continues after navigating away from
+            // this page and is naturally pretty error tolerant, but for the
+            // progress bar to be maintained this page is cached.
+            this.NavigationCacheMode = NavigationCacheMode.Required;
         }
 
         /// <summary>
@@ -191,7 +196,6 @@ namespace XBMCRemoteRT.Pages
 
         private async void CacheRefreshButton_Tapped(object sender, TappedRoutedEventArgs e)
         {
-            // TODO: What to do if the user navigates away from this page?
             CacheRefreshButton.IsEnabled = false;
             CacheRefreshProgressBar.Value = 0;
             RefreshStart.Begin();

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
@@ -207,13 +207,17 @@ namespace XBMCRemoteRT.Pages
 
             // Immediately load the cache. We don't want the user to see empty
             // and partially loaded images from cache misses.
-            IAsyncOperationWithProgress<int, int> initOperation = CacheManager.InitCacheAsync();
+            IAsyncOperationWithProgress<int, int> initOperation = CacheManager.UpdateCacheAsync();
             initOperation.Progress = (result, progress) =>
             {
                 // Cache write operation is slower. Weighted 70%
                 CacheRefreshProgressBar.Value = 30 + progress * 0.7;
             };
-            await initOperation;
+            int errors = await initOperation;
+            if (errors > 0)
+            {
+                // TODO: Handle failed image downloads with friendly error message "X images encountered errors..."
+            }
 
             RefreshEnd.Begin();
             CacheRefreshButton.IsEnabled = true;

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
@@ -248,6 +248,11 @@ namespace XBMCRemoteRT.Pages
             LoadButtonCheckedStates();
             LoadSkipJumpState();
             LoadAutoConnectState();
+
+            // Show cache controls only if authentication is in use
+            CacheRefreshPanel.Visibility =
+                ConnectionManager.CurrentConnection.HasCredentials() ?
+                Visibility.Visible : Visibility.Collapsed;
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
@@ -191,12 +191,17 @@ namespace XBMCRemoteRT.Pages
 
         private async void CacheRefreshButton_Tapped(object sender, TappedRoutedEventArgs e)
         {
+            // TODO: What to do if the user navigates away from this page?
             CacheRefreshButton.IsEnabled = false;
+            CacheRefreshProgressBar.Value = 0;
+            RefreshStart.Begin();
 
             // Clear the cache
             IAsyncOperationWithProgress<int, int> clearOperation = CacheManager.ClearCacheAsync();
             clearOperation.Progress = (result, progress) => {
-                // Progress is int 0 to 100
+                // The delete operation is much faster. Weighted 30% but no 
+                // real data to back up that estimate.
+                CacheRefreshProgressBar.Value = progress * 0.3;
             };
             await clearOperation;
 
@@ -205,10 +210,12 @@ namespace XBMCRemoteRT.Pages
             IAsyncOperationWithProgress<int, int> initOperation = CacheManager.InitCacheAsync();
             initOperation.Progress = (result, progress) =>
             {
-                // Progress is int 0 to 100
+                // Cache write operation is slower. Weighted 70%
+                CacheRefreshProgressBar.Value = 30 + progress * 0.7;
             };
             await initOperation;
 
+            RefreshEnd.Begin();
             CacheRefreshButton.IsEnabled = true;
         }
 

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
@@ -192,7 +192,11 @@ namespace XBMCRemoteRT.Pages
         private async void CacheRefreshButton_Tapped(object sender, TappedRoutedEventArgs e)
         {
             // Clear the cache
-            await CacheManager.ClearCacheAsync();
+            IAsyncOperationWithProgress<int, int> clearOperation = CacheManager.ClearCacheAsync();
+            clearOperation.Progress = (result, progress) => {
+                // Progress is int 0 to 100
+            };
+            await clearOperation;
 
             // Immediately load the cache. We don't want the user to see empty
             // and partially loaded images from cache misses.

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
@@ -220,7 +220,7 @@ namespace XBMCRemoteRT.Pages
             int errors = await initOperation;
             if (errors > 0)
             {
-                // TODO: Handle failed image downloads with friendly error message "X images encountered errors..."
+                // TODO: Consider a friendly error message "X images encountered errors..."
             }
 
             RefreshEnd.Begin();

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml.cs
@@ -189,6 +189,16 @@ namespace XBMCRemoteRT.Pages
             SettingsHelper.SetValue("AutoConnect", AutoconnectToggle.IsOn);
         }
 
+        private async void CacheRefreshButton_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            // Clear the cache
+            await CacheManager.ClearCacheAsync();
+
+            // Immediately load the cache. We don't want the user to see empty
+            // and partially loaded images from cache misses.
+            await CacheManager.InitCacheAsync();
+        }
+
         #region NavigationHelper registration
 
         /// <summary>


### PR DESCRIPTION
#27
* Media images app-wide are served from local cache. 
* The cache is updated in full on the first connection, and then only incrementally after that.
* Requests for new images are cached. (With the downsides we discussed a few comments ago.)
* A new action on the settings page allows a user to force a refresh of the entire cache.
* Progress of the time-intensive cache update is reported to the user.
* Cache actions are taken and displayed only on authenticated connections.
