### PR TITLE
Add sorting of album titles by track number in album page.

### DIFF
--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/Audio/AlbumPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/Audio/AlbumPage.xaml.cs
@@ -54,7 +54,8 @@ namespace XBMCRemoteRT.Pages.Audio
 
             ConnectionManager.ManageSystemTray(true);
             JObject filter = new JObject(new JProperty("albumid", GlobalVariables.CurrentAlbum.AlbumId));
-            songsInAlbum = await AudioLibrary.GetSongs(filter);
+            JObject sort = new JObject(new JProperty("method", "track"));
+            songsInAlbum = await AudioLibrary.GetSongs(filter, null, sort);
             SongsListView.ItemsSource = songsInAlbum;
 
             TrackCountTextBlock.Text = songsInAlbum.Count.ToString();


### PR DESCRIPTION
It seems the album page uses default sorting order for the song titles. Kodi seems to use the default sorting order of it's database which will comes to problems, if you add an incomplete album to your DB and add song titles later on. The JSON RPC API offers a sorting order to be applied. 

As I currently have no Windows platform available to install the IDE on, I cannot test this code, I hope it will do fine. Please excuse this, as this is my first contribution to an open source project ever :)