### PR TITLE
Update CoverPage.xaml - Wrong text displayed

### DIFF
--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/CoverPage.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/CoverPage.xaml
@@ -189,7 +189,7 @@
                         <BitmapIcon UriSource="/Assets/Icons/movie.png" Height="28" Foreground="{StaticResource PhoneForegroundBrush}" />
                         <StackPanel>
                             <TextBlock x:Uid="MoviesHubSectionHeader" Text="MOVIES" Margin="5,0,0,0"/>
-                            <TextBlock x:Uid="TVShowsHubSectionSubHeader" Text="see all movies" Style="{StaticResource HubSectionHeaderSubHeaderStyle}"/>
+                            <TextBlock x:Uid="MoviesHubSectionSubHeader" Text="see all movies" Style="{StaticResource HubSectionHeaderSubHeaderStyle}"/>
                         </StackPanel>
                     </StackPanel>
                 </HubSection.Header>


### PR DESCRIPTION
Wrong textblock Uid causing wrong text being displayed. Instead of "see all movies" was displayed "see all shows"