### PR TITLE
Add flyout menu with "queue song" in AlbumPage and ArtistDetailsHub.

### DIFF
--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/Audio/AlbumPage.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/Audio/AlbumPage.xaml
@@ -65,7 +65,12 @@
                     <ListView x:Name="SongsListView">
                         <ListView.ItemTemplate>
                             <DataTemplate>
-                                <StackPanel x:Name="SongItemWrapper" Orientation="Horizontal" Margin="0,10" Tapped="SongItemWrapper_Tapped">
+                                <StackPanel x:Name="SongItemWrapper" Orientation="Horizontal" Margin="0,10" Tapped="SongItemWrapper_Tapped" Holding="SongItemWrapper_Holding">
+                                    <FlyoutBase.AttachedFlyout>
+                                        <MenuFlyout>
+                                            <MenuFlyoutItem x:Name="QueueSongMFI" Text="queue song" Click="QueueSongMFI_Click" FontFamily="Global User Interface" DataContext="{Binding}" />
+                                        </MenuFlyout>
+                                    </FlyoutBase.AttachedFlyout>
                                     <Border BorderThickness="2" BorderBrush="{StaticResource PhoneForegroundBrush}" Background="Transparent" CornerRadius="25" Width="50" Height="50">
                                         <BitmapIcon Margin="12" UriSource="/Assets/Icons/musicnote.png" Foreground="{StaticResource PhoneForegroundBrush}" ></BitmapIcon>
                                     </Border>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/Audio/AlbumPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/Audio/AlbumPage.xaml.cs
@@ -153,5 +153,15 @@ namespace XBMCRemoteRT.Pages.Audio
         {
             Playlist.AddAlbum(GlobalVariables.CurrentAlbum);
         }
+
+        private void QueueSongMFI_Click(object sender, RoutedEventArgs e)
+        {
+            Playlist.AddSong((Song)(sender as MenuFlyoutItem).DataContext);
+        }
+
+        private void SongItemWrapper_Holding(object sender, HoldingRoutedEventArgs e)
+        {
+            FlyoutBase.ShowAttachedFlyout((FrameworkElement)sender);
+        }
     }
 }

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/Audio/ArtistDetailsHub.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/Audio/ArtistDetailsHub.xaml
@@ -61,7 +61,12 @@
                         <ListView x:Name="SongsListView" ItemsSource="{Binding}"  Margin="0,0,0,36">
                             <ListView.ItemTemplate>
                                 <DataTemplate>
-                                    <StackPanel x:Name="SongItemWrapper" Orientation="Horizontal" Margin="0,10" Tapped="SongItemWrapper_Tapped">
+                                    <StackPanel x:Name="SongItemWrapper" Orientation="Horizontal" Margin="0,10" Tapped="SongItemWrapper_Tapped" Holding="SongItemWrapper_Holding">
+                                        <FlyoutBase.AttachedFlyout>
+                                            <MenuFlyout>
+                                                <MenuFlyoutItem x:Name="QueueSongMFI" Text="queue song" Click="QueueSongMFI_Click" FontFamily="Global User Interface" DataContext="{Binding}"/>
+                                            </MenuFlyout>
+                                        </FlyoutBase.AttachedFlyout>
                                         <Border BorderThickness="2" BorderBrush="{StaticResource PhoneForegroundBrush}" Background="Transparent" CornerRadius="25" Width="50" Height="50">
                                             <BitmapIcon Margin="12" UriSource="/Assets/Icons/musicnote.png" Foreground="{StaticResource PhoneForegroundBrush}" ></BitmapIcon>
                                         </Border>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/Audio/ArtistDetailsHub.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/Audio/ArtistDetailsHub.xaml.cs
@@ -149,5 +149,15 @@ namespace XBMCRemoteRT.Pages.Audio
         {
             Playlist.AddArtist(GlobalVariables.CurrentArtist);
         }
+
+        private void QueueSongMFI_Click(object sender, RoutedEventArgs e)
+        {
+            Playlist.AddSong((Song)(sender as MenuFlyoutItem).DataContext);
+        }
+
+        private void SongItemWrapper_Holding(object sender, HoldingRoutedEventArgs e)
+        {
+            FlyoutBase.ShowAttachedFlyout((FrameworkElement)sender);
+        }
     }
 }


### PR DESCRIPTION
Commit a5b156fa2ed8a04650518ae70cb2ed54eaf257c7 added playlist support for artists, albums and songs. Adding songs to the playlist though was only possible in the "AllMusicPivot" page. With this change, you can queue specific songs in the AlbumPage and the ArtistDetailsHub, too.