### PR TITLE
Fix the 'Previous' remote button.

### DIFF
--- a/XBMCRemoteRT/XBMCRemoteRT.Windows/Pages/InputPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Windows/Pages/InputPage.xaml.cs
@@ -166,7 +166,7 @@ namespace XBMCRemoteRT.Pages
 
         private async void PreviousButton_Click(object sender, RoutedEventArgs e)
         {
-            await Player.GoTo(GlobalVariables.CurrentPlayerState.PlayerType, GoTo.Next);
+            await Player.GoTo(GlobalVariables.CurrentPlayerState.PlayerType, GoTo.Previous);
             await PlayerHelper.RefreshPlayerState();
         }
 

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml.cs
@@ -187,7 +187,7 @@ namespace XBMCRemoteRT.Pages
 
         private async void PreviousButton_Click(object sender, RoutedEventArgs e)
         {
-            await Player.GoTo(GlobalVariables.CurrentPlayerState.PlayerType, GoTo.Next);
+            await Player.GoTo(GlobalVariables.CurrentPlayerState.PlayerType, GoTo.Previous);
             await PlayerHelper.RefreshPlayerState();
         }
 


### PR DESCRIPTION
The button used to execute ```GoTo.Next``` and thus doing the same as the *Next* button. However, this typo only occurs on the InputPage and not on the CoverPage.