### PR TITLE
Added 'now playing' page which lists the currently playing songs

### DIFF
--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/App.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/App.xaml
@@ -29,7 +29,7 @@
                     <converters:PlayerTypeToBoolConverter x:Key="PlayerTypeToBoolConverter"/>
                     <converters:SecondsToStringConverter x:Key="SecondsToStringConverter"/>
                     <converters:DurationToStringConverter x:Key="DurationToStringConverter"/>
-
+                    
                 </ResourceDictionary>
 
                 <ResourceDictionary Source="PlatformSpecificStyles.xaml"/>

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/IdToColourConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/IdToColourConverter.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.ApplicationModel.Resources;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
+using XBMCRemoteRT.RPCWrappers;
+
+namespace XBMCRemoteRT.Converters
+{
+    public class IdToColourConverter : FrameworkElement, IValueConverter
+    {
+        #region CurrentItemId (DependencyProperty)
+        public int CurrentItemId
+        {
+            get { return GetValue(CurrentItemIdProperty) as int? ?? -1; }
+            set { SetValue(CurrentItemIdProperty, value); }
+        }
+        public static readonly DependencyProperty CurrentItemIdProperty = DependencyProperty.Register("CurrentItemId", typeof(int), typeof(IdToColourConverter), new PropertyMetadata("", OnCurrentItemIdChanged));
+
+        private static void OnCurrentItemIdChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((IdToColourConverter)d).OnCurrentItemIdChanged(e);
+        }
+
+        protected virtual void OnCurrentItemIdChanged(DependencyPropertyChangedEventArgs e)
+        {
+        }
+        #endregion
+
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            var currentAccentColorHex = (SolidColorBrush)Application.Current.Resources["PhoneAccentBrush"];
+            var normalColorHex = new SolidColorBrush(Colors.Transparent);
+
+            return ((int) value) == CurrentItemId ? currentAccentColorHex : normalColorHex;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/IdToColourConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/IdToColourConverter.cs
@@ -32,7 +32,13 @@ namespace XBMCRemoteRT.Converters
 
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            var currentAccentColorHex = (SolidColorBrush)Application.Current.Resources["PhoneAccentBrush"];
+            var currentAccentColorHex = new SolidColorBrush();
+            try
+            {
+                currentAccentColorHex = (SolidColorBrush) Application.Current.Resources["PhoneAccentBrush"];
+            }
+            catch (Exception) { }
+
             var normalColorHex = new SolidColorBrush(Colors.Transparent);
 
             return ((int) value) == CurrentItemId ? currentAccentColorHex : normalColorHex;

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/IdToThicknessConverter.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Converters/IdToThicknessConverter.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.ApplicationModel.Resources;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
+using XBMCRemoteRT.RPCWrappers;
+
+namespace XBMCRemoteRT.Converters
+{
+    public class IdToThicknessConverter : FrameworkElement, IValueConverter
+    {
+        #region CurrentItemId (DependencyProperty)
+        public int CurrentItemId
+        {
+            get { return GetValue(CurrentItemIdProperty) as int? ?? -1; }
+            set { SetValue(CurrentItemIdProperty, value); }
+        }
+        public static readonly DependencyProperty CurrentItemIdProperty = DependencyProperty.Register("CurrentItemId", typeof(int), typeof(IdToThicknessConverter), new PropertyMetadata("", OnCurrentItemIdChanged));
+
+        private static void OnCurrentItemIdChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((IdToThicknessConverter)d).OnCurrentItemIdChanged(e);
+        }
+
+        protected virtual void OnCurrentItemIdChanged(DependencyPropertyChangedEventArgs e)
+        {
+        }
+        #endregion
+
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            double dParam = 0.0;
+            double.TryParse((string)parameter, out dParam);
+            return ((int) value) == CurrentItemId ? new Thickness(0) : new Thickness(dParam);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/PlayerHelper.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Helpers/PlayerHelper.cs
@@ -33,6 +33,7 @@ namespace XBMCRemoteRT.Helpers
             JObject result = await Player.GetItem(player, properties);
             JObject item = (JObject)result["item"];
 
+            GlobalVariables.CurrentPlayerState.ItemId = (int)item["id"];
             GlobalVariables.CurrentPlayerState.Title = (string)item["title"];
             GlobalVariables.CurrentPlayerState.Artist = ((JArray)item["artist"]).ToObject<List<string>>();
             GlobalVariables.CurrentPlayerState.Fanart = (string)item["fanart"];

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Models/PlayerState.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Models/PlayerState.cs
@@ -16,6 +16,20 @@ namespace XBMCRemoteRT.Models
 
         #region PLAYER ITEMS
 
+        private int itemId;
+        public int ItemId
+        {
+            get { return itemId; }
+            set
+            {
+                if (itemId != value)
+                {
+                    itemId = value;
+                    NotifyPropertyChanged("ItemId");
+                }
+            }
+        }
+
         private string thumbnail;
         public string Thumbnail
         {
@@ -173,6 +187,7 @@ namespace XBMCRemoteRT.Models
             Speed = -1;
             TimeSeconds = 0;
             TotalTimeSeconds = 0;
+            ItemId = -1;
 
             PlayerType = Players.None;
         }

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/RPCWrappers/Player.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/RPCWrappers/Player.cs
@@ -56,6 +56,17 @@ namespace XBMCRemoteRT.RPCWrappers
             await ConnectionManager.ExecuteRPCRequest("Player.GoTo", parameters);
         }
 
+        public async static Task GoTo(Players player, int position)
+        {
+            if (player == Players.None)
+                return;
+            int playerId = getIdFromPlayers(player);
+            JObject parameters = new JObject(
+                new JProperty("playerid", playerId),
+                new JProperty("to", position));
+            await ConnectionManager.ExecuteRPCRequest("Player.GoTo", parameters);
+        }
+
         public async static Task<List<Players>> GetActivePlayers()
         {
             JObject responseObject = await ConnectionManager.ExecuteRPCRequest("Player.GetActivePlayers");

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/XBMCRemoteRT.Shared.projitems
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/XBMCRemoteRT.Shared.projitems
@@ -22,6 +22,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Converters\AuthBitmapConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\BoolToOpacityConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\CountToOpacityConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Converters\IdToThicknessConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Converters\IdToColourConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ListToStringConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ListTrimmer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\IPAddressConverter.cs" />

--- a/XBMCRemoteRT/XBMCRemoteRT.Windows/CoverPage.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.Windows/CoverPage.xaml
@@ -110,6 +110,11 @@
                                         <SymbolIcon Symbol="Next"/>
                                     </controls:RoundButton.Content>
                                 </controls:RoundButton>
+                                <controls:RoundButton x:Name="PlaylistButton" Click="PlaylistButton_Click">
+                                    <controls:RoundButton.Content>
+                                        <SymbolIcon Symbol="List"/>
+                                    </controls:RoundButton.Content>
+                                </controls:RoundButton>
                             </StackPanel>
                         </Grid>
                     </Grid>

--- a/XBMCRemoteRT/XBMCRemoteRT.Windows/CoverPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Windows/CoverPage.xaml.cs
@@ -205,5 +205,10 @@ namespace XBMCRemoteRT
             GlobalVariables.CurrentMovie = tappedMovie;
             Frame.Navigate(typeof(MovieDetailsHub));
         }
+
+        private void PlaylistButton_Click(object sender, RoutedEventArgs e)
+        {
+            Frame.Navigate(typeof (NowPlaying));
+        }
     }
 }

--- a/XBMCRemoteRT/XBMCRemoteRT.Windows/Pages/NowPlaying.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.Windows/Pages/NowPlaying.xaml
@@ -1,0 +1,116 @@
+﻿<Page
+    x:Class="XBMCRemoteRT.Pages.NowPlaying"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:XBMCRemoteRT.Pages"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converters="using:XBMCRemoteRT.Converters"
+    mc:Ignorable="d"
+    x:Name="pageRoot">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        
+        <Grid.ChildrenTransitions>
+            <TransitionCollection>
+                <EntranceThemeTransition/>
+            </TransitionCollection>
+        </Grid.ChildrenTransitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="140"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Back button and page title -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="120"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="backButton" Margin="39,59,39,0" Command="{Binding NavigationHelper.GoBackCommand, ElementName=pageRoot}"
+                        Style="{StaticResource NavigationBackButtonNormalStyle}"
+                        VerticalAlignment="Top"
+                        AutomationProperties.Name="Back"
+                        AutomationProperties.AutomationId="BackButton"
+                        AutomationProperties.ItemType="Navigation Button"/>
+            <TextBlock Text="{StaticResource AppName}" Style="{StaticResource SubheaderTextBlockStyle}" Grid.Column="1" 
+                        IsHitTestVisible="false" TextWrapping="NoWrap" VerticalAlignment="Bottom" Margin="0,0,30,90"/>
+            <TextBlock x:Name="pageTitle" Text="now playing" Style="{StaticResource HeaderTextBlockStyle}" Grid.Column="1" 
+                        IsHitTestVisible="false" TextWrapping="NoWrap" VerticalAlignment="Bottom" Margin="0,0,30,40"/>
+        </Grid>
+
+        <Grid Grid.Row="1" Margin="39,0" x:Name="NowPlayingGrid">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            
+            <Grid.Resources>
+                <converters:IdToColourConverter x:Name="IdToColourConverter" CurrentItemId="{Binding ItemId}"/>
+                <converters:IdToThicknessConverter x:Name="IdToThicknessConverter" CurrentItemId="{Binding ItemId}"/>
+            </Grid.Resources>
+
+            <Grid HorizontalAlignment="Left" Width="400" Margin="0,0,0,30" x:Name="PlaylistStats" >
+                <Border Height="40" CornerRadius="20" Background="#10FFFFFF" HorizontalAlignment="Left" VerticalAlignment="Top">
+                    <StackPanel Margin="12,0" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <TextBlock x:Name="TrackCountTextBlock" FontSize="22" Text="{Binding Tracks}" Foreground="{StaticResource PhoneAccentBrush}"/>
+                        <TextBlock x:Name="TracksTextBlock" FontSize="22" Text="tracks" Margin="4,0,0,0"/>
+                    </StackPanel>
+                </Border>
+
+                <Border x:Name="TotalPlaytime" Height="40" CornerRadius="20" Background="#10FFFFFF" HorizontalAlignment="Right" VerticalAlignment="Top">
+                    <StackPanel Margin="12,0" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <TextBlock x:Name="HoursEditTextBlock" FontSize="22" Text="{Binding TotalPlaytimeHours}" Foreground="{StaticResource PhoneAccentBrush}"/>
+                        <TextBlock x:Name="HoursLabelTextBlock" FontSize="22" Text="h" Margin="4,0,10,0"/>
+                        <TextBlock x:Name="MinutesEditTextBlock" FontSize="22" Text="{Binding TotalPlaytimeMinutes}" Foreground="{StaticResource PhoneAccentBrush}"/>
+                        <TextBlock x:Name="MinutesLabelTextBlock" FontSize="22" Text="m" Margin="4,0,0,0"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+
+            <GridView Grid.Row="1" ItemsSource="{Binding SongsInPlaylist}" SelectionMode="None">
+
+                <GridView.ItemContainerStyle>
+                    <Style TargetType="GridViewItem">
+                        <Setter Property="Width" Value="400" />
+                    </Style>
+                </GridView.ItemContainerStyle>
+
+                <GridView.ItemContainerTransitions>
+                    <TransitionCollection>
+                        <RepositionThemeTransition/>
+                    </TransitionCollection>
+                </GridView.ItemContainerTransitions>
+
+                <GridView.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel x:Name="SongItemWrapper" Orientation="Horizontal" Margin="0,10" Tapped="SongItemWrapper_Tapped" RightTapped="SongItemWrapper_OnRightTapped">
+                            <FlyoutBase.AttachedFlyout>
+                                <MenuFlyout>
+                                    <MenuFlyoutItem x:Name="RemoveSongMFI" Text="remove song" Click="RemoveSongMFI_Click" FontFamily="Global User Interface" DataContext="{Binding}" />
+                                </MenuFlyout>
+                            </FlyoutBase.AttachedFlyout>
+                            <Border 
+                                BorderThickness="{Binding SongId, Converter={StaticResource IdToThicknessConverter}, ConverterParameter='2.0'}" 
+                                BorderBrush="White" 
+                                Background="{Binding SongId, Converter={StaticResource IdToColourConverter}}" 
+                                CornerRadius="25" 
+                                Width="50" 
+                                Height="50">
+                                <BitmapIcon Margin="12" UriSource="/Assets/Icons/musicnote.png" Foreground="White" ></BitmapIcon>
+                            </Border>
+                            <StackPanel Orientation="Vertical">
+                                <TextBlock Text="{Binding Path=AlbumArtist[0]}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" FontSize="17" Margin="10,-2,0,0" FontWeight="Thin" Opacity="0.5" VerticalAlignment="Center" FontFamily="Global User Interface"/>
+                                <TextBlock Text="{Binding Label}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" FontSize="25" Margin="10,-2,0,0" FontWeight="SemiBold" VerticalAlignment="Center" FontFamily="Global User Interface"/>
+                                <TextBlock Text="{Binding Album}" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" FontSize="19" Margin="10,-2,0,0" FontWeight="Normal" Opacity="0.5" VerticalAlignment="Center" FontFamily="Global User Interface"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </DataTemplate>
+                </GridView.ItemTemplate>
+            </GridView>
+
+        </Grid>
+        
+    </Grid>
+</Page>

--- a/XBMCRemoteRT/XBMCRemoteRT.Windows/Pages/NowPlaying.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Windows/Pages/NowPlaying.xaml.cs
@@ -17,10 +17,9 @@ using Windows.UI.Xaml.Navigation;
 using XBMCRemoteRT.Common;
 using XBMCRemoteRT.Helpers;
 using XBMCRemoteRT.Models.Audio;
-using XBMCRemoteRT.Models.Common;
 using XBMCRemoteRT.RPCWrappers;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkID=390556
+// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
 
 namespace XBMCRemoteRT.Pages
 {
@@ -50,6 +49,12 @@ namespace XBMCRemoteRT.Pages
             navigationHelper = new NavigationHelper(this);
             navigationHelper.LoadState += this.NavigationHelper_LoadState;
             navigationHelper.SaveState += this.NavigationHelper_SaveState;
+            navigationHelper.GoBackCommand = new RelayCommand(() =>
+            {
+                navigationHelper.GoBack();
+            });
+
+            defaultViewModel["NavigationHelper"] = NavigationHelper;
 
             Loaded += NowPlaying_OnLoaded;
 
@@ -62,7 +67,7 @@ namespace XBMCRemoteRT.Pages
              * All this little piece of code does is just refreshing the
              * collection bound to the list of songs.
              ***************************************************************/
-            GlobalVariables.CurrentPlayerState.PropertyChanged += async (sender, args) => 
+            GlobalVariables.CurrentPlayerState.PropertyChanged += async (sender, args) =>
             {
                 if (args.PropertyName.Equals("ItemId"))
                 {
@@ -70,6 +75,7 @@ namespace XBMCRemoteRT.Pages
                 }
             };
         }
+
 
         private async void NowPlaying_OnLoaded(object sender, RoutedEventArgs routedEventArgs)
         {
@@ -104,7 +110,7 @@ namespace XBMCRemoteRT.Pages
                     if (tmpList.Any())
                         defaultViewModel["SongsInPlaylist"] = new ObservableCollection<Song>(tmpList);
                 }
-                catch(Exception){}
+                catch (Exception) { }
 
                 ConnectionManager.ManageSystemTray(false);
             }
@@ -145,7 +151,7 @@ namespace XBMCRemoteRT.Pages
             }
 
         }
-        
+
         /// <summary>
         /// Gets the <see cref="NavigationHelper"/> associated with this <see cref="Page"/>.
         /// </summary>
@@ -223,7 +229,7 @@ namespace XBMCRemoteRT.Pages
             if (stackPanel == null)
                 return;
 
-            var songs = ((ObservableCollection<Song>) defaultViewModel["SongsInPlaylist"]);
+            var songs = ((ObservableCollection<Song>)defaultViewModel["SongsInPlaylist"]);
 
             var tappedSong = stackPanel.DataContext as Song;
             await Playlist.Remove(PlayelistType.Audio, songs.IndexOf(tappedSong));
@@ -231,11 +237,6 @@ namespace XBMCRemoteRT.Pages
             songs.Remove(tappedSong);
 
             RefreshMetadata();
-        }
-
-        private void SongItemWrapper_OnHolding(object sender, HoldingRoutedEventArgs e)
-        {
-            FlyoutBase.ShowAttachedFlyout((FrameworkElement)sender);
         }
 
         private async void SongItemWrapper_Tapped(object sender, TappedRoutedEventArgs e)
@@ -248,6 +249,11 @@ namespace XBMCRemoteRT.Pages
 
             var tappedSong = stackPanel.DataContext as Song;
             await Player.GoTo(Players.Audio, songs.IndexOf(tappedSong));
+        }
+
+        private void SongItemWrapper_OnRightTapped(object sender, RightTappedRoutedEventArgs e)
+        {
+            FlyoutBase.ShowAttachedFlyout((FrameworkElement)sender);
         }
     }
 }

--- a/XBMCRemoteRT/XBMCRemoteRT.Windows/PlatformSpecificStyles.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.Windows/PlatformSpecificStyles.xaml
@@ -3,6 +3,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:XBMCRemoteRT">
 
+    <SolidColorBrush x:Key="PhoneAccentBrush">#FF00FF20</SolidColorBrush>
+
     <DataTemplate x:Name="SemanticZoomHeaderTemplate">
         <Grid Background="LightGray" Margin="0"
               Width="60" Height="60" >

--- a/XBMCRemoteRT/XBMCRemoteRT.Windows/XBMCRemoteRT.Windows.csproj
+++ b/XBMCRemoteRT/XBMCRemoteRT.Windows/XBMCRemoteRT.Windows.csproj
@@ -127,6 +127,9 @@
     <Compile Include="Pages\InputPage.xaml.cs">
       <DependentUpon>InputPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Pages\NowPlaying.xaml.cs">
+      <DependentUpon>NowPlaying.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Pages\Video\AllMoviesPage.xaml.cs">
       <DependentUpon>AllMoviesPage.xaml</DependentUpon>
     </Compile>
@@ -243,6 +246,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Pages\InputPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Pages\NowPlaying.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/CoverPage.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/CoverPage.xaml
@@ -235,19 +235,24 @@
                             </Grid>
                         </StackPanel>
                         <Grid Grid.Row="3" VerticalAlignment="Bottom">
-                            <AppBarButton x:Name="PlayPauseButton" Margin="0,-7,0,0" Click="PlayPauseButton_Click" Style="{StaticResource ExtraLargeRoundButton}" IsEnabled="{Binding PlayerType, Converter={StaticResource PlayerTypeToBoolConverter}}">
-                                <AppBarButton.Icon>
-                                    <SymbolIcon Symbol="{Binding Speed, Converter={StaticResource SpeedToSymbolIconConverter}}" RenderTransformOrigin="0.5,0.5" >
-                                        <SymbolIcon.RenderTransform>
-                                            <CompositeTransform ScaleX="1.6" ScaleY="1.6"/>
-                                        </SymbolIcon.RenderTransform>
-                                    </SymbolIcon>
-                                </AppBarButton.Icon>
-                            </AppBarButton>
+                            <StackPanel Orientation="Horizontal" >
+                                <AppBarButton x:Name="PlayPauseButton" Click="PlayPauseButton_Click" Style="{StaticResource ExtraLargeRoundButton}" IsEnabled="{Binding PlayerType, Converter={StaticResource PlayerTypeToBoolConverter}}">
+                                    <AppBarButton.Icon>
+                                        <SymbolIcon Symbol="{Binding Speed, Converter={StaticResource SpeedToSymbolIconConverter}}" RenderTransformOrigin="0.5,0.5" >
+                                            <SymbolIcon.RenderTransform>
+                                                <CompositeTransform ScaleX="1.6" ScaleY="1.6"/>
+                                            </SymbolIcon.RenderTransform>
+                                        </SymbolIcon>
+                                    </AppBarButton.Icon>
+                                </AppBarButton>
 
-                            <AppBarButton x:Name="PreviousButton" Margin="80,9,0,0" Click="PreviousButton_Click" Icon="Previous" Style="{StaticResource LargeRoundButton}" IsEnabled="{Binding PlayerType, Converter={StaticResource PlayerTypeToBoolConverter}}"/>
+                                <AppBarButton x:Name="PreviousButton" VerticalAlignment="Center" Click="PreviousButton_Click" Icon="Previous" Style="{StaticResource LargeRoundButton}" IsEnabled="{Binding PlayerType, Converter={StaticResource PlayerTypeToBoolConverter}}"/>
 
-                            <AppBarButton x:Name="NextButton" Margin="135,9,0,0" Click="NextButton_Click" Icon="Next" Style="{StaticResource LargeRoundButton}" IsEnabled="{Binding PlayerType, Converter={StaticResource PlayerTypeToBoolConverter}}"/>
+                                <AppBarButton x:Name="NextButton" VerticalAlignment="Center" Click="NextButton_Click" Icon="Next" Style="{StaticResource LargeRoundButton}" IsEnabled="{Binding PlayerType, Converter={StaticResource PlayerTypeToBoolConverter}}"/>
+
+                                <AppBarButton x:Name="CurrentPlaylistButton" VerticalAlignment="Center" Click="CurrentPlaylistButton_Click" Icon="List" Style="{StaticResource LargeRoundButton}" IsEnabled="{Binding PlayerType, Converter={StaticResource PlayerTypeToBoolConverter}}"/>
+
+                            </StackPanel>
 
                         </Grid>
                     </Grid>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/CoverPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/CoverPage.xaml.cs
@@ -236,6 +236,11 @@ namespace XBMCRemoteRT
             await PlayerHelper.RefreshPlayerState();
         }
 
+        private void CurrentPlaylistButton_Click(object sender, RoutedEventArgs e)
+        {
+            Frame.Navigate(typeof (NowPlaying));
+        }
+
         private void AboutAppBarButton_Click(object sender, RoutedEventArgs e)
         {
             Frame.Navigate(typeof(AboutPivot));

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/AddConnectionPage.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/AddConnectionPage.xaml
@@ -29,11 +29,11 @@
         <Grid Grid.Row="1" x:Name="ContentRoot" Margin="12,0">
             <ScrollViewer>
                 <StackPanel Margin="0,0,0,36">
-                    <TextBox x:Name="NameTextBox" x:Uid="ConnectionName" InputScope="NameOrPhoneNumber" Header="Name"/>
-                    <TextBox x:Name="IPTextBox" x:Uid="ServerAddress" Header="Server address"/>
-                    <TextBox x:Name="PortTextBox" x:Uid="Port" InputScope="Number" Text="80" Header="Port"/>
-                    <TextBox x:Name="UsernameTextBox" x:Uid="Username" Text="xbmc" Header="Username"/>
-                    <TextBox x:Name="PasswordTextBox" x:Uid="Password" Header="Password"/>
+                    <TextBox x:Name="NameTextBox" x:Uid="ConnectionName" Header="Name"/>
+                    <TextBox x:Name="IPTextBox" x:Uid="ServerAddress" Header="Server address" InputScope="Url" />
+                    <TextBox x:Name="PortTextBox" x:Uid="Port" Text="80" Header="Port" InputScope="Number" />
+                    <TextBox x:Name="UsernameTextBox" x:Uid="Username" Header="Username" Text="xbmc" InputScope="NameOrPhoneNumber"/>
+                    <TextBox x:Name="PasswordTextBox" x:Uid="Password" Header="Password" InputScope="NameOrPhoneNumber"/>
                     <TextBlock x:Uid="WarningNote" Style="{StaticResource ParagraphTextStyle}" />
                 </StackPanel>
             </ScrollViewer>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/AddConnectionPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/AddConnectionPage.xaml.cs
@@ -124,17 +124,36 @@ namespace XBMCRemoteRT.Pages
                 return;
             }
 
-            if (NameTextBox.Text.Equals(string.Empty) || IPTextBox.Text.Equals(string.Empty))
+            String ipAddress = IPTextBox.Text;
+
+            if (NameTextBox.Text.Equals(string.Empty) || ipAddress.Equals(string.Empty))
             {
                 MessageDialog msg = new MessageDialog("Please enter valid name and server address", "Invalid Details");
                 await msg.ShowAsync();
                 return;
             }
 
+            // ********************************************************************************************* //
+            // Michele Mischitelli (11/07/2015) :
+            // We should check for ip addresses starting with http:// in case people use dynamic DNS to always 
+            // be able to connect to their kodi at home. Https:// is not supported for now.
+            const String httpsPrefix = "https://";
+            if (ipAddress.ToLower().StartsWith(httpsPrefix))
+            {
+                var md = new MessageDialog("Https protocol is not currently supported.", "Invalid protocol");
+                await md.ShowAsync();
+                return;
+            }
+
+            const String httpPrefix = "http://";
+            if (ipAddress.ToLower().StartsWith(httpPrefix))
+                ipAddress = ipAddress.Substring(httpPrefix.Length);
+            // ********************************************************************************************* //
+
             var newConnection = new ConnectionItem
             {
                 ConnectionName = NameTextBox.Text,
-                IpAddress = IPTextBox.Text,
+                IpAddress = ipAddress,
                 Port = port,
                 Username = UsernameTextBox.Text,
                 Password = PasswordTextBox.Text

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/EditConnectionPage.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/EditConnectionPage.xaml
@@ -29,11 +29,11 @@
         <Grid Grid.Row="1" x:Name="ContentRoot" Margin="12,0">
             <ScrollViewer>
                 <StackPanel Margin="0,0,0,36">
-                    <TextBox x:Name="NameTextBox" x:Uid="ConnectionName" InputScope="NameOrPhoneNumber" Header="Name" Text="{Binding ConnectionName}"/>
-                    <TextBox x:Name="IPTextBox" x:Uid="ServerAddress" Header="Server address" Text="{Binding IpAddress}"/>
-                    <TextBox x:Name="PortTextBox" x:Uid="Port" InputScope="Number" Header="Port" Text="{Binding Port}"/>
-                    <TextBox x:Name="UsernameTextBox" x:Uid="Username" Header="Username" Text="{Binding Username}"/>
-                    <TextBox x:Name="PasswordTextBox" x:Uid="Password" Header="Password" Text="{Binding Password}"/>                    
+                    <TextBox x:Name="NameTextBox" x:Uid="ConnectionName" Header="Name" Text="{Binding ConnectionName}"/>
+                    <TextBox x:Name="IPTextBox" x:Uid="ServerAddress" Header="Server address" Text="{Binding IpAddress}" InputScope="Url" />
+                    <TextBox x:Name="PortTextBox" x:Uid="Port" Header="Port" Text="{Binding Port}" InputScope="Number" />
+                    <TextBox x:Name="UsernameTextBox" x:Uid="Username" Header="Username" Text="{Binding Username}" InputScope="NameOrPhoneNumber" />
+                    <TextBox x:Name="PasswordTextBox" x:Uid="Password" Header="Password" Text="{Binding Password}" InputScope="NameOrPhoneNumber" />                    
                     <TextBlock x:Uid="WakeOnLan" Text="WAKE ON LAN" Style="{StaticResource ResourceKey=ParagraphHeaderTextStyle}" Margin="0,12,0,0"/>
                     <ToggleSwitch x:Name="WOLEnabledToggle" IsOn="{Binding IsWakable}" x:Uid="WOLToggle" Header="Enable wake on LAN for this server"/>
                     <TextBox x:Name="MACAddressTextBox" x:Uid="MAC" Header="MAC address" Text="{Binding MACAddress, Converter={StaticResource MACAddressConverter}}" PlaceholderText="11:22:33:44:55:66" IsEnabled="{Binding IsOn, ElementName=WOLEnabledToggle}" />

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/EditConnectionPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/EditConnectionPage.xaml.cs
@@ -116,12 +116,30 @@ namespace XBMCRemoteRT.Pages
                 return;
             }
 
-            if (NameTextBox.Text.Equals(string.Empty) || IPTextBox.Text.Equals(string.Empty))
+            String ipAddress = IPTextBox.Text;
+            if (NameTextBox.Text.Equals(string.Empty) || ipAddress.Equals(string.Empty))
             {
                 MessageDialog msg = new MessageDialog("Please enter valid name and server address", "Invalid Details");
                 await msg.ShowAsync();
                 return;
             }
+
+            // ********************************************************************************************* //
+            // Michele Mischitelli (11/07/2015) :
+            // We should check for ip addresses starting with http:// in case people use dynamic DNS to always 
+            // be able to connect to their kodi at home. Https:// is not supported for now.
+            const String httpsPrefix = "https://";
+            if (ipAddress.ToLower().StartsWith(httpsPrefix))
+            {
+                var md = new MessageDialog("Https protocol is not currently supported.", "Invalid protocol");
+                await md.ShowAsync();
+                return;
+            }
+
+            const String httpPrefix = "http://";
+            if (ipAddress.ToLower().StartsWith(httpPrefix))
+                ipAddress = ipAddress.Substring(httpPrefix.Length);
+            // ********************************************************************************************* //
 
             if (WOLEnabledToggle.IsOn)
             {
@@ -141,7 +159,7 @@ namespace XBMCRemoteRT.Pages
             }
 
             currentConnection.ConnectionName = NameTextBox.Text;
-            currentConnection.IpAddress = IPTextBox.Text;
+            currentConnection.IpAddress = ipAddress;
             currentConnection.Port = port;
             currentConnection.Username = UsernameTextBox.Text;
             currentConnection.Password = PasswordTextBox.Text;

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/NowPlaying.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/NowPlaying.xaml
@@ -1,0 +1,103 @@
+﻿<Page
+    x:Class="XBMCRemoteRT.Pages.NowPlaying"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:XBMCRemoteRT.Pages"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converters="using:XBMCRemoteRT.Converters"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    x:Name="NowPlayingPage">
+
+    <Page.Transitions>
+        <TransitionCollection>
+            <NavigationThemeTransition>
+                <NavigationThemeTransition.DefaultNavigationTransitionInfo>
+                    <ContinuumNavigationTransitionInfo/>
+                </NavigationThemeTransition.DefaultNavigationTransitionInfo>
+            </NavigationThemeTransition>
+        </TransitionCollection>
+    </Page.Transitions>
+
+    <Grid>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Title Panel -->
+        <StackPanel Grid.Row="0" Margin="12,0,0,0">
+            <TextBlock Text="KODI ASSIST" Margin="3,12,0,-8"  Style="{StaticResource PageTitleTextStyle}"/>
+            <TextBlock Text="NOW PLAYING" x:Uid="NowPlayingHeader" Style="{StaticResource PageHeaderTextStyle}"/>
+        </StackPanel>
+
+        <!--TODO: Content should be placed within the following grid-->
+        <Grid Grid.Row="1" Margin="12,15,12,0">
+            <ScrollViewer>
+                <StackPanel Margin="0,0,0,36">
+                    <StackPanel.Resources>
+                        <converters:IdToColourConverter x:Name="IdToColourConverter" CurrentItemId="{Binding ItemId}"/>
+                        <converters:IdToThicknessConverter x:Name="IdToThicknessConverter" CurrentItemId="{Binding ItemId}"/>
+                    </StackPanel.Resources>
+                    
+                    <Grid Margin="0,0,0,30" x:Name="PlaylistStats" >
+                        <Border Height="40" CornerRadius="20" Background="{StaticResource PhoneChromeBrush}" HorizontalAlignment="Left" VerticalAlignment="Top">
+                            <StackPanel Margin="12,0" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <TextBlock x:Name="TrackCountTextBlock" FontSize="22" Text="{Binding Tracks}" Foreground="{StaticResource PhoneAccentBrush}"/>
+                                <TextBlock x:Name="TracksTextBlock" FontSize="22" Text="tracks" Margin="4,0,0,0"/>
+                            </StackPanel>
+                        </Border>
+                        
+                        <Border x:Name="TotalPlaytime" Height="40" CornerRadius="20" Background="{StaticResource PhoneChromeBrush}" HorizontalAlignment="Right" VerticalAlignment="Top">
+                            <StackPanel Margin="12,0" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <TextBlock x:Name="HoursEditTextBlock" FontSize="22" Text="{Binding TotalPlaytimeHours}" Foreground="{StaticResource PhoneAccentBrush}"/>
+                                <TextBlock x:Name="HoursLabelTextBlock" FontSize="22" Text="h" Margin="4,0,10,0"/>
+                                <TextBlock x:Name="MinutesEditTextBlock" FontSize="22" Text="{Binding TotalPlaytimeMinutes}" Foreground="{StaticResource PhoneAccentBrush}"/>
+                                <TextBlock x:Name="MinutesLabelTextBlock" FontSize="22" Text="m" Margin="4,0,0,0"/>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                    
+                    <ListView ItemsSource="{Binding SongsInPlaylist}">
+
+                        <ListView.ItemContainerTransitions>
+                            <TransitionCollection>
+                                <RepositionThemeTransition/>
+                            </TransitionCollection>
+                        </ListView.ItemContainerTransitions>
+
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel x:Name="SongItemWrapper" Orientation="Horizontal" Margin="0,10" Tapped="SongItemWrapper_Tapped" Holding="SongItemWrapper_OnHolding">
+                                    <FlyoutBase.AttachedFlyout>
+                                        <MenuFlyout>
+                                            <MenuFlyoutItem x:Name="RemoveSongMFI" Text="remove song" Click="RemoveSongMFI_Click" FontFamily="Global User Interface" DataContext="{Binding}" />
+                                        </MenuFlyout>
+                                    </FlyoutBase.AttachedFlyout>
+                                    <Border 
+                                        BorderThickness="{Binding SongId, Converter={StaticResource IdToThicknessConverter}, ConverterParameter='2.0'}" 
+                                        BorderBrush="{StaticResource PhoneForegroundBrush}" 
+                                        Background="{Binding SongId, Converter={StaticResource IdToColourConverter}}" 
+                                        CornerRadius="25" 
+                                        Width="50" 
+                                        Height="50">
+                                        <BitmapIcon Margin="12" UriSource="/Assets/Icons/musicnote.png" Foreground="{StaticResource PhoneForegroundBrush}" ></BitmapIcon>
+                                    </Border>
+                                    <StackPanel Orientation="Vertical">
+                                        <TextBlock Text="{Binding Path=AlbumArtist[0]}" FontSize="17" Margin="10,-2,0,0" FontWeight="Thin" Opacity="0.5" VerticalAlignment="Center" FontFamily="Global User Interface"/>
+                                        <TextBlock Text="{Binding Label}" FontSize="25" Margin="10,-2,0,0" FontWeight="SemiBold" VerticalAlignment="Center" FontFamily="Global User Interface"/>
+                                        <TextBlock Text="{Binding Album}" FontSize="19" Margin="10,-2,0,0" FontWeight="Normal" Opacity="0.5" VerticalAlignment="Center" FontFamily="Global User Interface"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </StackPanel>
+                
+            </ScrollViewer>
+        </Grid>
+
+        </Grid>
+</Page>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/NowPlaying.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/NowPlaying.xaml.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using XBMCRemoteRT.Common;
+using XBMCRemoteRT.Helpers;
+using XBMCRemoteRT.Models.Audio;
+using XBMCRemoteRT.Models.Common;
+using XBMCRemoteRT.RPCWrappers;
+
+// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkID=390556
+
+namespace XBMCRemoteRT.Pages
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class NowPlaying : Page
+    {
+        private NavigationHelper navigationHelper;
+        private ObservableDictionary defaultViewModel = new ObservableDictionary();
+
+        public NowPlaying()
+        {
+            InitializeComponent();
+            defaultViewModel["SongsInPlaylist"] = new ObservableCollection<Song>();
+            defaultViewModel["TotalPlaytimeHours"] = "0";
+            defaultViewModel["TotalPlaytimeMinutes"] = "0";
+            defaultViewModel["Tracks"] = "0";
+
+            DataContext = defaultViewModel;
+
+            PlaylistStats.Visibility = Visibility.Collapsed;
+
+            IdToColourConverter.DataContext = GlobalVariables.CurrentPlayerState;
+            IdToThicknessConverter.DataContext = GlobalVariables.CurrentPlayerState;
+
+            navigationHelper = new NavigationHelper(this);
+            navigationHelper.LoadState += this.NavigationHelper_LoadState;
+            navigationHelper.SaveState += this.NavigationHelper_SaveState;
+
+            Loaded += NowPlaying_OnLoaded;
+
+            /***************************************************************
+             * THIS IS AWFULL. THIS IS THE EVIL WITHIN XAML. A needed evil.
+             * -------------------------------------------------------------
+             * Microsoft won't add multibinding to WinRT, so programmers
+             * get creative an pissed off, doing stuff like this.
+             * 
+             * All this little piece of code does is just refreshing the
+             * collection bound to the list of songs.
+             ***************************************************************/
+            GlobalVariables.CurrentPlayerState.PropertyChanged += async (sender, args) => 
+            {
+                if (args.PropertyName.Equals("ItemId"))
+                {
+                    await RefreshSongs();
+                }
+            };
+        }
+
+        private async void NowPlaying_OnLoaded(object sender, RoutedEventArgs routedEventArgs)
+        {
+            await RefreshSongs();
+            RefreshMetadata();
+
+            PlaylistStats.Visibility = Visibility.Visible;
+        }
+
+        private async Task RefreshSongs()
+        {
+            var rpcRequestFallback = true;
+
+            if (DefaultViewModel.ContainsKey("SongsInPlaylist"))
+            {
+                var songs = ((ObservableCollection<Song>)defaultViewModel["SongsInPlaylist"]);
+                if (songs.Any())
+                {
+                    defaultViewModel["SongsInPlaylist"] = null;
+                    defaultViewModel["SongsInPlaylist"] = songs;
+                    rpcRequestFallback = false;
+                }
+            }
+
+            if (rpcRequestFallback)
+            {
+                ConnectionManager.ManageSystemTray(true);
+
+                var tmpList = (List<Song>)await Playlist.GetItems(PlayelistType.Audio);
+                if (tmpList.Any())
+                    defaultViewModel["SongsInPlaylist"] = new ObservableCollection<Song>(tmpList);
+
+                ConnectionManager.ManageSystemTray(false);
+            }
+        }
+
+        private void RefreshMetadata()
+        {
+            if (!DefaultViewModel.ContainsKey("SongsInPlaylist"))
+                return;
+
+            var songs = ((ObservableCollection<Song>)defaultViewModel["SongsInPlaylist"]);
+            if (!songs.Any())
+                return;
+
+            var loader = new Windows.ApplicationModel.Resources.ResourceLoader();
+            string track = loader.GetString("Track");
+            string tracks = loader.GetString("Tracks");
+
+            long totalPlaytimeSec = songs.Aggregate(0, (x, y) => x + y.Duration);
+
+            TrackCountTextBlock.Text = songs.Count().ToString();
+            TracksTextBlock.Text = songs.Count() > 1 ? tracks : track;
+
+            defaultViewModel["Tracks"] = songs.Count.ToString();
+            defaultViewModel["TotalPlaytimeHours"] = Math.Floor(totalPlaytimeSec / 3600.0).ToString("F0");
+            defaultViewModel["TotalPlaytimeMinutes"] = ((totalPlaytimeSec / 60.0) % 60).ToString("F0").PadLeft(2, '0');
+
+            if (defaultViewModel["TotalPlaytimeHours"].Equals("0"))
+            {
+                HoursEditTextBlock.Visibility = Visibility.Collapsed;
+                HoursLabelTextBlock.Visibility = Visibility.Collapsed;
+
+                if (defaultViewModel["TotalPlaytimeMinutes"].Equals("00"))
+                {
+                    TotalPlaytime.Visibility = Visibility.Collapsed;
+                    TotalPlaytime.Visibility = Visibility.Collapsed;
+                }
+            }
+
+        }
+        
+        /// <summary>
+        /// Gets the <see cref="NavigationHelper"/> associated with this <see cref="Page"/>.
+        /// </summary>
+        public NavigationHelper NavigationHelper
+        {
+            get { return this.navigationHelper; }
+        }
+
+        /// <summary>
+        /// Gets the view model for this <see cref="Page"/>.
+        /// This can be changed to a strongly typed view model.
+        /// </summary>
+        public ObservableDictionary DefaultViewModel
+        {
+            get { return this.defaultViewModel; }
+        }
+
+        /// <summary>
+        /// Populates the page with content passed during navigation.  Any saved state is also
+        /// provided when recreating a page from a prior session.
+        /// </summary>
+        /// <param name="sender">
+        /// The source of the event; typically <see cref="NavigationHelper"/>
+        /// </param>
+        /// <param name="e">Event data that provides both the navigation parameter passed to
+        /// <see cref="Frame.Navigate(Type, Object)"/> when this page was initially requested and
+        /// a dictionary of state preserved by this page during an earlier
+        /// session.  The state will be null the first time a page is visited.</param>
+        private void NavigationHelper_LoadState(object sender, LoadStateEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Preserves state associated with this page in case the application is suspended or the
+        /// page is discarded from the navigation cache.  Values must conform to the serialization
+        /// requirements of <see cref="SuspensionManager.SessionState"/>.
+        /// </summary>
+        /// <param name="sender">The source of the event; typically <see cref="NavigationHelper"/></param>
+        /// <param name="e">Event data that provides an empty dictionary to be populated with
+        /// serializable state.</param>
+        private void NavigationHelper_SaveState(object sender, SaveStateEventArgs e)
+        {
+        }
+
+        #region NavigationHelper registration
+
+        /// <summary>
+        /// The methods provided in this section are simply used to allow
+        /// NavigationHelper to respond to the page's navigation methods.
+        /// <para>
+        /// Page specific logic should be placed in event handlers for the  
+        /// <see cref="NavigationHelper.LoadState"/>
+        /// and <see cref="NavigationHelper.SaveState"/>.
+        /// The navigation parameter is available in the LoadState method 
+        /// in addition to page state preserved during an earlier session.
+        /// </para>
+        /// </summary>
+        /// <param name="e">Provides data for navigation methods and event
+        /// handlers that cannot cancel the navigation request.</param>
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            GlobalVariables.CurrentTracker.SendView("AlbumPage");
+            this.navigationHelper.OnNavigatedTo(e);
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            this.navigationHelper.OnNavigatedFrom(e);
+        }
+
+        #endregion
+
+        private async void RemoveSongMFI_Click(object sender, RoutedEventArgs e)
+        {
+            var stackPanel = sender as MenuFlyoutItem;
+            if (stackPanel == null)
+                return;
+
+            var songs = ((ObservableCollection<Song>) defaultViewModel["SongsInPlaylist"]);
+
+            var tappedSong = stackPanel.DataContext as Song;
+            await Playlist.Remove(PlayelistType.Audio, songs.IndexOf(tappedSong));
+
+            songs.Remove(tappedSong);
+
+            RefreshMetadata();
+        }
+
+        private void SongItemWrapper_OnHolding(object sender, HoldingRoutedEventArgs e)
+        {
+            FlyoutBase.ShowAttachedFlyout((FrameworkElement)sender);
+        }
+
+        private async void SongItemWrapper_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            var stackPanel = sender as StackPanel;
+            if (stackPanel == null)
+                return;
+
+            var songs = ((ObservableCollection<Song>)defaultViewModel["SongsInPlaylist"]);
+
+            var tappedSong = stackPanel.DataContext as Song;
+            await Player.GoTo(Players.Audio, songs.IndexOf(tappedSong));
+        }
+    }
+}

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/XBMCRemoteRT.WindowsPhone.csproj
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/XBMCRemoteRT.WindowsPhone.csproj
@@ -136,6 +136,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Pages\NowPlaying.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Pages\SettingsPivot.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -213,6 +217,9 @@
     </Compile>
     <Compile Include="Pages\InputPage.xaml.cs">
       <DependentUpon>InputPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Pages\NowPlaying.xaml.cs">
+      <DependentUpon>NowPlaying.xaml</DependentUpon>
     </Compile>
     <Compile Include="Pages\SettingsPivot.xaml.cs">
       <DependentUpon>SettingsPivot.xaml</DependentUpon>


### PR DESCRIPTION
- Added the NowPlaying page which lists (for now) the currently playing audio tracks.
- To allow the NowPlaying page to display which item is the one currently playing I've added a ItemId in the PlayerState global class.
- Player RPCWrapper can now play the n-th element in a list (not just prev, next).
- Kodi Assist supports now server addresses starting with http:// (in case a user configured his kodi to be accessible from outside thanks to the various free dyndns services).
- Https protocol is not supported and a message pops up if the user tries to setup such an address.