### PR TITLE
advanced menu item "Suspend" added to WP

### DIFF
--- a/XBMCRemoteRT.sln
+++ b/XBMCRemoteRT.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "XBMCRemoteRT", "XBMCRemoteRT", "{A7ADAFBB-AC8D-4FEA-AC5F-1FCC0AC75447}"
 EndProject

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/RPCWrappers/Input.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/RPCWrappers/Input.cs
@@ -9,9 +9,15 @@ using XBMCRemoteRT.Helpers;
 
 namespace XBMCRemoteRT.RPCWrappers
 {
-    public enum InputCommands { Home, Back, Select, Left, Up, Right, Down, ShowOSD, ShowCodec, Info, ContextMenu};
+    public enum InputCommands { Home, Back, Select, Left, Up, Right, Down, ShowOSD, ShowCodec, Info, ContextMenu };
+    public enum SystemCommands { Suspend }  // option to send system commands to Kodi, like "System.Suspend"
     public class Input
     {
+        public static async Task ExecuteAction(SystemCommands command)
+        {
+            await ConnectionManager.ExecuteRPCRequest("System." + command.ToString());
+        }
+
         public static async Task ExecuteAction(InputCommands command)
         {           
             await ConnectionManager.ExecuteRPCRequest("Input." + command.ToString());

--- a/XBMCRemoteRT/XBMCRemoteRT.Shared/Strings/en-US/Resources.resw
+++ b/XBMCRemoteRT/XBMCRemoteRT.Shared/Strings/en-US/Resources.resw
@@ -616,4 +616,7 @@ And to top it all, the app is fully open source. You can view, edit and modify e
   <data name="AboutShareLink.Text" xml:space="preserve">
     <value>spread the love</value>
   </data>
+  <data name="Suspend" xml:space="preserve">
+    <value>suspend Kodi</value>
+  </data>
 </root>

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml
@@ -483,6 +483,13 @@
                         <FontIcon FontFamily="ms-appx:///Assets/iconFont.ttf#iconFont" FontSize="45" Margin="0,5,0,0"  Glyph="&#57605;"/>
                     </AppBarButton.Icon>
                 </AppBarButton>
+
+                <AppBarButton x:Name="ShowInfoButton" Click="ShowInfoButton_Click" Margin="0,0,24,245" Style="{StaticResource ExtraLargeRoundButton}" VerticalAlignment="Bottom" HorizontalAlignment="Right" RenderTransformOrigin="0.489,-2.075">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="Segoe WP Black" FontSize="45" Margin="0,5,0,0"  Glyph="i" FontStyle="Italic"/>
+                    </AppBarButton.Icon>
+                </AppBarButton>
+
             </Grid>
 
             <!--Primary commands-->

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml
@@ -411,24 +411,9 @@
                         <SymbolIcon Symbol="Home"/>
                     </AppBarButton.Icon>
                 </AppBarButton>
-                <AppBarButton x:Name="OSDButton" Click="OSDButton_Click" Style="{StaticResource LargeRoundButton}" Margin="3,0,3,0" Grid.Column="1" Visibility="Collapsed">
-                    <AppBarButton.Icon>
-                        <SymbolIcon Symbol="Page2"/>
-                    </AppBarButton.Icon>
-                </AppBarButton>
                 <AppBarButton x:Name="TextInputButton" Style="{StaticResource LargeRoundButton}" Margin="3,0,3,0" Grid.Column="2" Click="TextInputButton_Click" Visibility="Visible">
                     <AppBarButton.Icon>
                         <SymbolIcon Symbol="Rename"/>
-                    </AppBarButton.Icon>
-                </AppBarButton>
-                <AppBarButton x:Name="SubtitlesButton" Style="{StaticResource LargeRoundButton}" Margin="3,0,3,0" Grid.Column="3" Click="SubtitlesButton_Click" Visibility="Collapsed">
-                    <AppBarButton.Icon>
-                        <SymbolIcon Symbol="ClosedCaption"/>
-                    </AppBarButton.Icon>
-                </AppBarButton>
-                <AppBarButton x:Name="InfoButton" Style="{StaticResource LargeRoundButton}" Margin="3,0,3,0" Grid.Column="4" Click="InfoButton_Click" Visibility="Collapsed">
-                    <AppBarButton.Icon>
-                        <SymbolIcon Symbol="DockBottom"/>
                     </AppBarButton.Icon>
                 </AppBarButton>
                 <AppBarButton x:Name="AdvancedButton" Style="{StaticResource LargeRoundButton}" Margin="3,0,3,0" Grid.Column="5" Click="AdvancedButton_Click" Visibility="Visible">
@@ -438,6 +423,21 @@
                     <AppBarButton.Flyout>
                         <ListPickerFlyout x:Name="AdvancedMenuFlyout" Placement="Full" ItemsPicked="AdvancedMenuFlyout_ItemsPicked" />
                     </AppBarButton.Flyout>
+                </AppBarButton>
+                <AppBarButton x:Name="SubtitlesButton" Style="{StaticResource LargeRoundButton}" Margin="3,0,3,0" Grid.Column="3" Click="SubtitlesButton_Click" Visibility="Collapsed">
+                    <AppBarButton.Icon>
+                        <SymbolIcon Symbol="ClosedCaption"/>
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton x:Name="OSDButton" Click="OSDButton_Click" Style="{StaticResource LargeRoundButton}" Margin="3,0,3,0" Grid.Column="1" Visibility="Collapsed">
+                    <AppBarButton.Icon>
+                        <SymbolIcon Symbol="Page2"/>
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton x:Name="InfoButton" Style="{StaticResource LargeRoundButton}" Margin="3,0,3,0" Grid.Column="4" Click="InfoButton_Click" Visibility="Collapsed">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="i" FontFamily="Segoe WP Black" FontStyle="Italic" FontSize="14"/>
+                    </AppBarButton.Icon>
                 </AppBarButton>
             </Grid>
 
@@ -481,12 +481,6 @@
                 <AppBarButton x:Name="MenuButton" Click="MenuButton_Click" Margin="0,0,24,10" Style="{StaticResource ExtraLargeRoundButton}" VerticalAlignment="Bottom" HorizontalAlignment="Right">
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="ms-appx:///Assets/iconFont.ttf#iconFont" FontSize="45" Margin="0,5,0,0"  Glyph="&#57605;"/>
-                    </AppBarButton.Icon>
-                </AppBarButton>
-
-                <AppBarButton x:Name="ShowInfoButton" Click="ShowInfoButton_Click" Margin="0,0,24,245" Style="{StaticResource ExtraLargeRoundButton}" VerticalAlignment="Bottom" HorizontalAlignment="Right" RenderTransformOrigin="0.489,-2.075">
-                    <AppBarButton.Icon>
-                        <FontIcon FontFamily="Segoe WP Black" FontSize="45" Margin="0,5,0,0"  Glyph="i" FontStyle="Italic"/>
                     </AppBarButton.Icon>
                 </AppBarButton>
 

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml.cs
@@ -197,6 +197,11 @@ namespace XBMCRemoteRT.Pages
             Input.ExecuteAction(InputCommands.Back);
         }
 
+        private void ShowInfoButton_Click(object sender, RoutedEventArgs e)
+        {
+            Input.ExecuteAction(InputCommands.Info);
+        }
+
         #endregion
 
         private async void PreviousButton_Click(object sender, RoutedEventArgs e)

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml.cs
@@ -197,11 +197,6 @@ namespace XBMCRemoteRT.Pages
             Input.ExecuteAction(InputCommands.Back);
         }
 
-        private void ShowInfoButton_Click(object sender, RoutedEventArgs e)
-        {
-            Input.ExecuteAction(InputCommands.Info);
-        }
-
         #endregion
 
         private async void PreviousButton_Click(object sender, RoutedEventArgs e)

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml.cs
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/InputPage.xaml.cs
@@ -349,6 +349,7 @@ namespace XBMCRemoteRT.Pages
         private string showSubtitleSerach;// = "download subtitles";
         private string showVideoInfo;// = "show codec info";
         private string shutDown;// = "shut down";
+        private string suspendServer;// = "suspend"
 
         private void PopulateFlyout()
         {
@@ -359,9 +360,10 @@ namespace XBMCRemoteRT.Pages
             videoLibClean = loader.GetString("CleanVideoLibrary");
             showSubtitleSerach = loader.GetString("DownloadSubtitles");
             showVideoInfo = loader.GetString("ShowCodecInfo");
-            shutDown = loader.GetString("ShutDown");
+            shutDown = loader.GetString("ShutDown"); // this string is missing in Resources.resw so it doesn't work, altough this function is not usable since it is better invoked from Kodi menu
+            suspendServer = loader.GetString("Suspend"); //string Suspend is added to Resources.resw, translations should be updated
 
-            AdvancedMenuFlyout.ItemsSource = new List<string> { audioLibUpdate, videoLibUpdate, audioLibClean, videoLibClean, showSubtitleSerach, showVideoInfo, shutDown };
+            AdvancedMenuFlyout.ItemsSource = new List<string> { audioLibUpdate, videoLibUpdate, audioLibClean, videoLibClean, showSubtitleSerach, showVideoInfo, shutDown, suspendServer};
         }
 
         private void AdvancedMenuFlyout_ItemsPicked(ListPickerFlyout sender, ItemsPickedEventArgs args)
@@ -380,6 +382,8 @@ namespace XBMCRemoteRT.Pages
                 GUI.ShowSubtitleSearch();
             else if (pickedCommand == showVideoInfo)
                 Input.ExecuteAction("codecinfo");
+            else if (pickedCommand == suspendServer)
+                Input.ExecuteAction(SystemCommands.Suspend);  // send command System.Suspend to Kodi server - sleep
             else if (pickedCommand == shutDown)
             {
                 Applikation.Quit();

--- a/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
+++ b/XBMCRemoteRT/XBMCRemoteRT.WindowsPhone/Pages/SettingsPivot.xaml
@@ -157,7 +157,7 @@
                             </CheckBox>
                             <CheckBox x:Name="InfoCheckBox" Style="{StaticResource RoundButtonCheckBoxStyle}" >
                                 <CheckBox.Content>
-                                    <SymbolIcon Symbol="DockBottom"/>
+                                    <FontIcon Glyph="i" FontFamily="Segoe WP Black" FontStyle="Italic" FontSize="14"/>
                                 </CheckBox.Content>
                             </CheckBox>
                         </StackPanel>


### PR DESCRIPTION
Hi akshay2000, I checked the code and decided to join Kodi Assist. I hope that you will decide to accept my small contribution. It is added in dev branch.

I added option in for Windows phone Advanced Menu to send Suspend command to Kodi server. Depending on server, it should put it so sleep. I tested it on Mac OS X and Windows 8.1 server and it works (Mac enters Sleep state, Windows enters Sleep). If afterwards I use WOL, both can be awaken again with Kodi running. I find it useful (especially if used with WOL option). Thus, I can use Kodi Assist Remote on WP for both waking the server and suspending it (I always put Kodi server to sleep at night to conserve power).
To achieve that I added public static async Task ExecuteAction(SystemCommands command). So far I added only Suspend command, but it could be used for other System commands in the future.
I also added string "Suspend" in Resource.resw so that it can be translated to other languages.

In second commit I added "Info" button on Remote (ShowInfoButton in InputPage.xaml), however it didn't look symmetric, so I changed just the style on 3rd commit, so it gets clear to user what is the purpose of that button ("i" as a symbol for Info).

Please consider those changes and give your comment. I believe that new "Suspend" item is the most needed change.

Another point regarding Resource.resw: you are missing definition for "shutDown" string there. Therefore, Shutdown option is not displayed in Advanced Menu, but in my oppinion, this option is useless and maybe it is better to leave it out (I didn't fix that altough it is easy fix). Shutdown Kodi app on server just leaves user without control. User then need either keyboard or RDP or VNC to start Kodi again. 
I would propose to change Shutdown option to actually power off Kodi machine, i.e. to send System.Shutdown message via ExecuteAction task. Users would have option for Suspend or Shutdown when they want to save power. What do you think?